### PR TITLE
With this change, assetic will generate the correct url for the JS files.

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -4,7 +4,7 @@
 {% spaceless %}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
    
-    <script type="text/javascript" src="/bundles/ivoryckeditor/ckeditor.js"></script>
+    <script type="text/javascript" src="{{ asset('bundles/ivoryckeditor/ckeditor.js') }}"></script>
     <script type="text/javascript">
         CKEDITOR.replace("{{ id }}",{
             toolbar: {{ toolbar | json_encode | raw }},


### PR DESCRIPTION
The bundle fails if the app aren´t in the root of the site (you are using a absolute url for the JS).
With this change, assetic will generate the correct url for the JS files.
