### PR TITLE
Added 'configs' parameter for access to all CKEditor parameter settings

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -22,7 +22,8 @@ class CKEditorType extends AbstractType
     {
         $builder
             ->setAttribute('toolbar', $options['toolbar'])
-            ->setAttribute('ui_color', $options['ui_color']);
+            ->setAttribute('ui_color', $options['ui_color'])
+            ->setAttribute('configs', $options['configs']);
     }
 
     /**
@@ -30,9 +31,16 @@ class CKEditorType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        $configs = array_merge(
+            $form->getAttribute('configs'),
+            array(
+                'toolbar'      => $form->getAttribute('toolbar'),
+                'ui_color'     => $form->getAttribute('ui_color'),
+            )
+        );
+
         $view->vars = array_replace($view->vars, array(
-            'toolbar'      => $form->getAttribute('toolbar'),
-            'ui_color'     => $form->getAttribute('ui_color'),
+            'configs' => $configs
         ));
     }
 
@@ -91,7 +99,8 @@ class CKEditorType extends AbstractType
                     'items' => array('Maximize', 'ShowBlocks','-','About')
                 )
             ),
-            'ui_color' => null
+            'ui_color' => null,
+            'configs' => array()
         ));
 
         $resolver->addAllowedValues(array('required' => array(false)));

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -77,6 +77,15 @@ $toolbar = array(
 
 Describes the base user interface color to be used by the editor.
 
+### Extra configs
+
+   - option: configs
+   - type: array
+   - default: array()
+
+Any extra config parameters can be added here. These will be passed directly to the editor instance.
+See here for the various options that can be configured this way by CKEditor: [http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html](http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html)
+
 ### Max length
 
    - option: max_length

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -19,12 +19,7 @@
                 instance.destroy(true);
             }
 
-            CKEDITOR.replace("{{ id }}",{
-                toolbar: {{ toolbar | json_encode | raw }},
-                {% if ui_color is not null %}
-                    uiColor: {{ ui_color }},
-                {% endif %}
-            });
+            CKEDITOR.replace("{{ id }}", {{ configs | json_encode | raw }});
         {% endautoescape %}
     </script>
 {% endspaceless %}


### PR DESCRIPTION
This will fix both #15 and #17 and provide essential access to all of the config parameters available with CKEditor!

Simply set the 'configs' parameter when building your form.

```
$formBuilder
    ->add('content', 'ckeditor', array('configs' => array( ... ));
```

Any parameters from here should work:
http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html
