### PR TITLE
Add PHP templating engine support

### DIFF
--- a/DependencyInjection/IvoryCKEditorExtension.php
+++ b/DependencyInjection/IvoryCKEditorExtension.php
@@ -45,15 +45,11 @@ class IvoryCKEditorExtension extends Extension
     protected function register(array $config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-
         foreach (array('helper', 'form') as $service) {
             $loader->load($service.'.xml');
         }
 
-        $container->setParameter('twig.form.resources', array_merge(
-            $container->getParameter('twig.form.resources'),
-            array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig')
-        ));
+        $this->registerResources($container);
 
         $container->setParameter('ivory_ck_editor.form.type.enable', $config['enable']);
         $container->setParameter('ivory_ck_editor.form.type.base_path', $config['base_path']);
@@ -67,6 +63,34 @@ class IvoryCKEditorExtension extends Extension
             if (!empty($config['plugins'])) {
                 $this->registerPlugins($config, $container);
             }
+        }
+    }
+
+    /**
+     * Registers the form resources for the PHP & Twig templating engines.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container The container.
+     */
+    protected function registerResources(ContainerBuilder $container)
+    {
+        $templatingEngines = $container->getParameter('templating.engines');
+
+        if (in_array('php', $templatingEngines)) {
+            $container->setParameter('templating.helper.form.resources', array_merge(
+                $container->hasParameter('templating.helper.form.resources')
+                    ? $container->getParameter('templating.helper.form.resources')
+                    : array(),
+                array('IvoryCKEditorBundle:Form')
+            ));
+        }
+
+        if (in_array('twig', $templatingEngines)) {
+            $container->setParameter('twig.form.resources', array_merge(
+                $container->hasParameter('twig.form.resources')
+                    ? $container->getParameter('twig.form.resources')
+                    : array(),
+                array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig')
+            ));
         }
     }
 

--- a/Resources/views/Form/ckeditor_widget.html.php
+++ b/Resources/views/Form/ckeditor_widget.html.php
@@ -1,0 +1,21 @@
+<textarea <?php echo $view['form']->renderBlock('attributes') ?>><?php echo $value ?></textarea>
+
+<?php if ($enable) : ?>
+    <script type="text/javascript">
+        var CKEDITOR_BASEPATH = '<?php echo $base_path ?>';
+    </script>
+
+    <script type="text/javascript" src="<?php echo $js_path ?>"></script>
+
+    <script type="text/javascript">
+        if (CKEDITOR.instances['<?php echo $id ?>']) {
+            delete CKEDITOR.instances['<?php echo $id ?>'];
+        }
+
+        <?php foreach ($plugins as $pluginName => $plugin): ?>
+            CKEDITOR.plugins.addExternal('<?php echo $pluginName ?>', '<?php echo $plugin['path'] ?>', '<?php echo $plugin['filename'] ?>');
+        <?php endforeach; ?>
+
+        CKEDITOR.replace('<?php echo $id ?>', <?php echo $config ?>);
+    </script>
+<?php endif; ?>

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -1,7 +1,4 @@
-{% form_theme form _self %}
-
 {% block ckeditor_widget %}
-{% spaceless %}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 
     {% if enable %}
@@ -23,5 +20,4 @@
             CKEDITOR.replace('{{ id }}', {{ config | raw }});
         </script>
     {% endif %}
-{% endspaceless %}
 {% endblock %}

--- a/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
@@ -49,7 +49,7 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
         $this->container->set('templating.helper.assets', $this->assetsHelperMock);
         $this->container->set('router', $this->routerMock);
 
-        $this->container->setParameter('twig.form.resources', array());
+        $this->container->setParameter('templating.engines', array('php', 'twig'));
 
         $this->container->registerExtension($extension = new IvoryCKEditorExtension());
         $this->container->loadFromExtension($extension->getAlias());
@@ -97,22 +97,24 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
         );
     }
 
-    /**
-     * This test checks if the ckeditor widget is weel add to the available form twig ressources but it does not work
-     * (Anyway, I have checked in a Symfony SE & all works fine).
-     *
-     * With my test bootstrap (see setUp), in a first time, the widget is well added but in a second time, it is
-     * override by the default value. Maybe someone with a better understood of the DI component can solve it :)
-     */
     public function testTwigResources()
     {
-//        // FIXME
-//        $this->container->compile();
-//
-//        $this->assertTrue(in_array(
-//            'IvoryCKEditorBundle:Form:ckeditor_widget.html.twig',
-//            $this->container->getParameter('twig.form.resources'))
-//        );
+        $this->container->compile();
+
+        $this->assertTrue(in_array(
+            'IvoryCKEditorBundle:Form:ckeditor_widget.html.twig',
+            $this->container->getParameter('twig.form.resources'))
+        );
+    }
+
+    public function testPhpResources()
+    {
+        $this->container->compile();
+
+        $this->assertTrue(in_array(
+            'IvoryCKEditorBundle:Form',
+            $this->container->getParameter('templating.helper.form.resources'))
+        );
     }
 
     public function testDisable()

--- a/Tests/Template/AbstractTemplateTest.php
+++ b/Tests/Template/AbstractTemplateTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\Template;
+
+/**
+ * Abstract template test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Renders a template.
+     *
+     * @param array $context The template context.
+     *
+     * @return string The template output.
+     */
+    abstract protected function renderTemplate(array $context = array());
+
+    /**
+     * Normalizes the output by removing the heading whitespaces.
+     *
+     * @param string $output The output.
+     *
+     * @return string The normalized output.
+     */
+    protected function normalizeOutput($output)
+    {
+        return preg_replace('/^\s+/m', '', $output);
+    }
+
+    public function testRenderWithSimpleWidget()
+    {
+        $output = $this->renderTemplate(array(
+            'id'        => 'id',
+            'value'     => 'value',
+            'enable'    => true,
+            'base_path' => 'base_path',
+            'js_path'   => 'js_path',
+            'config'    => json_encode(array(), JSON_FORCE_OBJECT),
+            'plugins'   => array(),
+        ));
+
+        $expected = <<<EOF
+<textarea >value</textarea>
+<script type="text/javascript">
+var CKEDITOR_BASEPATH = 'base_path';
+</script>
+<script type="text/javascript" src="js_path"></script>
+<script type="text/javascript">
+if (CKEDITOR.instances['id']) {
+delete CKEDITOR.instances['id'];
+}
+CKEDITOR.replace('id', {});
+</script>
+
+EOF;
+
+        $this->assertSame($expected, $this->normalizeOutput($output));
+    }
+
+    public function testRenderWithFullWidget()
+    {
+        $output = $this->renderTemplate(array(
+            'id'        => 'id',
+            'value'     => 'value',
+            'enable'    => true,
+            'base_path' => 'base_path',
+            'js_path'   => 'js_path',
+            'config'    => json_encode(array('foo' => 'bar'), JSON_FORCE_OBJECT),
+            'plugins'   => array('foo' => array('path' => 'path', 'filename' => 'filename')),
+        ));
+
+        $expected = <<<EOF
+<textarea >value</textarea>
+<script type="text/javascript">
+var CKEDITOR_BASEPATH = 'base_path';
+</script>
+<script type="text/javascript" src="js_path"></script>
+<script type="text/javascript">
+if (CKEDITOR.instances['id']) {
+delete CKEDITOR.instances['id'];
+}
+CKEDITOR.plugins.addExternal('foo', 'path', 'filename');
+CKEDITOR.replace('id', {"foo":"bar"});
+</script>
+
+EOF;
+
+        $this->assertSame($expected, $this->normalizeOutput($output));
+    }
+
+    public function testRenderWithDisableWidget()
+    {
+        $output = $this->renderTemplate(array(
+            'id'     => 'id',
+            'value'  => 'value',
+            'enable' => false,
+        ));
+
+        $expected = <<<EOF
+<textarea >value</textarea>
+
+EOF;
+
+        $this->assertSame($expected, $this->normalizeOutput($output));
+    }
+}

--- a/Tests/Template/PhpTemplateTest.php
+++ b/Tests/Template/PhpTemplateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\Template;
+
+use Symfony\Component\Templating\Loader\FilesystemLoader,
+    Symfony\Component\Templating\PhpEngine,
+    Symfony\Component\Templating\TemplateNameParser;
+
+/**
+ * PHP template test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class PhpTemplateTest extends AbstractTemplateTest
+{
+    /** @var \Symfony\Component\Templating\PhpEngine */
+    protected $phpEngine;
+
+    /** @var \Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper */
+    protected $formHelperMock;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->phpEngine = new PhpEngine(
+            new TemplateNameParser(),
+            new FilesystemLoader(__DIR__.'/../../Resources/views/Form/%name%')
+        );
+
+        $this->formHelperMock = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->formHelperMock
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('form'));
+
+        $this->phpEngine->addHelpers(array($this->formHelperMock));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->formHelper);
+        unset($this->phpEngine);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function renderTemplate(array $context = array())
+    {
+        return $this->phpEngine->render('ckeditor_widget.html.php', $context);
+    }
+}

--- a/Tests/Template/TwigTemplateTest.php
+++ b/Tests/Template/TwigTemplateTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\Template;
+
+use Twig_Environment,
+    Twig_Loader_Filesystem;
+
+/**
+ * Twig template test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class TwigTemplateTest extends AbstractTemplateTest
+{
+    /** @var \Twig_Environment */
+    protected $twig;
+
+    /** @var \Twig_Template */
+    protected $template;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->twig = new Twig_Environment(new Twig_Loader_Filesystem(__DIR__.'/../../Resources/views/Form'));
+        $this->template = $this->twig->loadTemplate('ckeditor_widget.html.twig');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->template);
+        unset($this->twig);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function renderTemplate(array $context = array())
+    {
+        return $this->template->render($context);
+    }
+}


### PR DESCRIPTION
This PR adds support for the PHP templating engine & so, fix #29. 

It uses #32 as base but I propose it in a new PR as it will be hard for @geoffrey-brier to rebase his work on top of the last updates...

Before merging, I would like to fix the "FIX ME" part of this PR (for Twig too) & add some tests about templates (generate each of them & check if the output is right).
