### PR TITLE
Update documentation to deal with the change where `ui_color` become `uiColor`

### DIFF
--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -13,7 +13,7 @@ ivory_ck_editor:
     configs:
         my_config:
             toolbar:                [ [ "Source", "-", "Save" ], "/", [ "Anchor" ], "/", [ "Maximize" ] ]
-            ui_color:               "#000000"
+            uiColor:               "#000000"
             filebrowserUploadRoute: "my_route"
             extraPlugins:           "wordcount"
             # ...
@@ -32,7 +32,7 @@ If you want to override some parts of the defined config, you can still use the 
 ``` php
 $builder->add('field', 'ckeditor', array(
     'config_name' => 'my_config',
-    'config'      => array('ui_color' => '#ffffff'),
+    'config'      => array('uiColor' => '#ffffff'),
 ));
 ```
 
@@ -57,15 +57,15 @@ ivory_ck_editor:
     configs:
         my_config_1:
             toolbar:  "my_toolbar_1"
-            ui_color: "#000000"
+            uiColor: "#000000"
             # ...
         my_config_2:
             toolbar:  "my_toolbar_2"
-            ui_color: "#ffffff"
+            uiColor: "#ffffff"
             # ...
         my_config_2:
             toolbar:  "my_toolbar_1"
-            ui_color: "#cccccc"
+            uiColor: "#cccccc"
     toolbars:
         configs:
             my_toolbar_1: [ [ "Source", "-", "Save" ], "/", [ "Anchor" ], "/", [ "Maximize" ] ]
@@ -80,11 +80,11 @@ ivory_ck_editor:
     configs:
         my_config_1:
             toolbar:  "my_toolbar_1"
-            ui_color: "#000000"
+            uiColor: "#000000"
             # ...
         my_config_2:
             toolbar:  "my_toolbar_2"
-            ui_color: "#ffffff"
+            uiColor: "#ffffff"
             # ...
     toolbars:
         configs:

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -25,7 +25,7 @@ $builder->add('field', 'ckeditor', array(
                 'items' => array('Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat'),
             ),
         ),
-        'ui_color' => '#ffffff',
+        'uiColor' => '#ffffff',
         //...
     ),
 ));

--- a/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
@@ -148,7 +148,7 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
                     '/',
                     array('Maximize'),
                 ),
-                'ui_color' => '#000000',
+                'uiColor' => '#000000',
             ),
         );
 
@@ -176,7 +176,7 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
                     '/',
                     array('Maximize'),
                 ),
-                'ui_color' => '#000000',
+                'uiColor' => '#000000',
             ),
             'custom' => array(
                 'toolbar' => array(
@@ -184,7 +184,7 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
                     '/',
                     array('Anchor'),
                 ),
-                'ui_color' => '#ffffff',
+                'uiColor' => '#ffffff',
             ),
         );
 

--- a/Tests/Fixtures/config/yaml/invalid_default_config.yml
+++ b/Tests/Fixtures/config/yaml/invalid_default_config.yml
@@ -2,4 +2,4 @@ ivory_ck_editor:
     default_config: bar
     configs:
         foo:
-            ui_color: "#000000"
+            uiColor: "#000000"

--- a/Tests/Fixtures/config/yaml/multiple_configuration.yml
+++ b/Tests/Fixtures/config/yaml/multiple_configuration.yml
@@ -3,10 +3,10 @@ ivory_ck_editor:
     configs:
         default:
             toolbar:  "default"
-            ui_color: "#000000"
+            uiColor: "#000000"
         custom:
             toolbar:  "custom"
-            ui_color: "#ffffff"
+            uiColor: "#ffffff"
     toolbars:
         configs:
             default: [ "@document", "/", [ "Anchor" ], "/", "@tools" ]

--- a/Tests/Fixtures/config/yaml/single_configuration.yml
+++ b/Tests/Fixtures/config/yaml/single_configuration.yml
@@ -3,7 +3,7 @@ ivory_ck_editor:
     configs:
         default:
             toolbar:  "default"
-            ui_color: "#000000"
+            uiColor: "#000000"
     toolbars:
         configs:
             default: [ "@document", "/", [ "Anchor" ], "/", "@tools" ]

--- a/Tests/Form/Type/CKEditorTypeTest.php
+++ b/Tests/Form/Type/CKEditorTypeTest.php
@@ -192,7 +192,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'config' => array(
                 'toolbar'  => array('foo' => 'bar'),
-                'ui_color' => '#ffffff',
+                'uiColor' => '#ffffff',
             ),
         );
 
@@ -218,7 +218,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $config = array(
             'toolbar'  => 'default',
-            'ui_color' => '#ffffff',
+            'uiColor' => '#ffffff',
         );
 
         $this->configManagerMock
@@ -243,7 +243,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $options = array(
             'toolbar'  => array('foo' => 'bar'),
-            'ui_color' => '#ffffff',
+            'uiColor' => '#ffffff',
         );
 
         $this->configManagerMock
@@ -273,10 +273,10 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $configuredConfig = array(
             'toolbar'  => 'default',
-            'ui_color' => '#ffffff',
+            'uiColor' => '#ffffff',
         );
 
-        $explicitConfig = array('ui_color' => '#000000');
+        $explicitConfig = array('uiColor' => '#000000');
 
         $this->configManagerMock
             ->expects($this->once())
@@ -398,7 +398,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'config' => array(
                 'toolbar'  => array('foo' => 'bar'),
-                'ui_color' => '#ffffff',
+                'uiColor' => '#ffffff',
             ),
             'plugins' => array(
                 'wordcount' => array(
@@ -424,7 +424,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             'enable' => false,
             'config' => array(
                 'toolbar'  => array('foo' => 'bar'),
-                'ui_color' => '#ffffff',
+                'uiColor' => '#ffffff',
             ),
             'plugins' => array(
                 'wordcount' => array(

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,14 +9,14 @@ The `ConfigManagerInterface` now supports default configuration. You need to imp
 
 ### 1.0.0 to 1.1.0 - 2.0.0 to 2.1.0
 
-The `toolbar` & `ui_color` options have been removed in favor of the `config` option which allows a more flexible
+The `toolbar` & `uiColor` options have been removed in favor of the `config` option which allows a more flexible
 configuration.
 
 Before:
 
 ``` php
 $builder->add('field', 'ckeditor', array(
-    'ui_color' => '#ffffff',
+    'uiColor' => '#ffffff',
     'toolbar'  => array(
         // ...
     ),
@@ -28,7 +28,7 @@ After:
 ``` php
 $builder->add('field', 'ckeditor', array(
     'config' => array(
-        'ui_color' => '#ffffff',
+        'uiColor' => '#ffffff',
         'toolbar'  => array(
             // ...
         ),


### PR DESCRIPTION
As CKEditor documentation describe the parameter to configure the color of the UI is `uiColor` and not `ui_color`.

close #42
