### PR TITLE
Add allowed values for "required" option

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -289,7 +289,7 @@ class CKEditorType extends AbstractType
             'plugins'     => 'array',
         ));
 
-        $resolver->addAllowedValues(array('required' => array(false)));
+        $resolver->addAllowedValues(array('required' => array(true, false)));
     }
 
     /**


### PR DESCRIPTION
This bundle does not work correctly with Symfony 2.3.\* without "true" in allowed values for "required" option
