### PR TITLE
[Form] Simplify default configuration handling

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -225,10 +225,6 @@ class CKEditorType extends AbstractType
             $builder->setAttribute('base_path', $options['base_path']);
             $builder->setAttribute('js_path', $options['js_path']);
 
-            if ($options['config_name'] === null) {
-                $options['config_name'] = $this->configManager->getDefaultConfig();
-            }
-
             $config = $options['config'];
             if ($options['config_name'] === null) {
                 $name = uniqid('ivory', true);
@@ -274,7 +270,7 @@ class CKEditorType extends AbstractType
             'enable'      => $this->enable,
             'base_path'   => $this->basePath,
             'js_path'     => $this->jsPath,
-            'config_name' => null,
+            'config_name' => $this->configManager->getDefaultConfig(),
             'config'      => array(),
             'plugins'     => array(),
         );


### PR DESCRIPTION
This PR simplifies the handling of the default configuration by making it as default value in the form instead of determining it dynamically in the buildForm.
