### PR TITLE
[ConfigManager] Allow to define filebrowser*Url via a closure

### DIFF
--- a/Model/ConfigManager.php
+++ b/Model/ConfigManager.php
@@ -242,22 +242,25 @@ class ConfigManager implements ConfigManagerInterface
     protected function handleFileBrowser(array $config)
     {
         $filebrowser = function ($key, array &$config, RouterInterface $router) {
+            $filebrowserHandler = 'filebrowser'.$key.'Handler';
             $filebrowserRoute = 'filebrowser'.$key.'Route';
+            $filebrowserRouteParameters = 'filebrowser'.$key.'RouteParameters';
+            $filebrowserRouteAbsolute = 'filebrowser'.$key.'RouteAbsolute';
 
-            if (isset($config[$filebrowserRoute])) {
-                $filebrowserRouteParameters = 'filebrowser'.$key.'RouteParameters';
-                $filebrowserRouteAbsolute = 'filebrowser'.$key.'RouteAbsolute';
-
+            if (isset($config[$filebrowserHandler])) {
+                $config['filebrowser'.$key.'Url'] = $config[$filebrowserHandler]($router);
+            } elseif (isset($config[$filebrowserRoute])) {
                 $config['filebrowser'.$key.'Url'] = $router->generate(
                     $config[$filebrowserRoute],
                     isset($config[$filebrowserRouteParameters]) ? $config[$filebrowserRouteParameters] : array(),
                     isset($config[$filebrowserRouteAbsolute]) ? $config[$filebrowserRouteAbsolute] : false
                 );
-
-                unset($config[$filebrowserRoute]);
-                unset($config[$filebrowserRouteParameters]);
-                unset($config[$filebrowserRouteAbsolute]);
             }
+
+            unset($config[$filebrowserHandler]);
+            unset($config[$filebrowserRoute]);
+            unset($config[$filebrowserRouteParameters]);
+            unset($config[$filebrowserRouteAbsolute]);
         };
 
         $filebrowser('Browse', $config, $this->router);

--- a/Resources/doc/file_browse_upload.md
+++ b/Resources/doc/file_browse_upload.md
@@ -5,13 +5,38 @@ related to URLs which allows to manage file browse/upload. As explain
 [here](http://symfony.com/doc/current/book/routing.html), Symfony provides a powerfull routing component allowing you
 to generate URLs. These concepts are directly managed by the bundle by adding three new options for each "*Url" option:
 
-For example, the filebrowserBrowseUrl options can be generated with these three new options:
+For example, the filebrowserBrowseUrl option can be generated with these three new options:
 
   * filebrowserBrowseRoute
   * filebrowserBrowseRouteParameters
   * filebrowserBrowseRouteAbsolute
 
-The concerned options are:
+``` php
+$builder->add('field', 'ckeditor', array(
+    'config' => array(
+        'filebrowserBrowseRoute'           => 'my_route',
+        'filebrowserBrowseRouteParameters' => array('slug' => 'my-slug'),
+        'filebrowserBrowseRouteAbsolute'   => true,
+    ),
+));
+```
+
+If this process does not fit your needs, you can use the `filebrowser*Handler` option allowing you to build your own
+url with a simple closure:
+
+``` php
+$builder->add('field', 'ckeditor', array(
+    'config' => array(
+        'filebrowserBrowseHandler' => function (RouterInterface $router) {
+            return $router->generate('my_route', array('slug' => 'my-slug', true);
+        },
+    ),
+));
+```
+
+A closure will allow you to use the `use` keyword in order to make it aware of your own dependencies :)
+
+These features are about the following options:
 
  * filebrowserBrowseUrl
  * filebrowserFlashBrowseUrl

--- a/Tests/Model/ConfigManagerTest.php
+++ b/Tests/Model/ConfigManagerTest.php
@@ -12,6 +12,7 @@
 namespace Ivory\CKEditorBundle\Tests\Model;
 
 use Ivory\CKEditorBundle\Model\ConfigManager;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Config manager test.
@@ -198,6 +199,36 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
                 'filebrowser'.$filebrowser.'Route'           => 'browse_route',
                 'filebrowser'.$filebrowser.'RouteParameters' => array('foo' => 'bar'),
                 'filebrowser'.$filebrowser.'RouteAbsolute'   => true,
+            )
+        );
+
+        $this->assertSame(
+            array('filebrowser'.$filebrowser.'Url' => 'browse_url'),
+            $this->configManager->getConfig('foo')
+        );
+    }
+
+    /**
+     * @dataProvider filebrowserProvider
+     */
+    public function testConfigFileBrowserHandler($filebrowser)
+    {
+        $this->routerMock
+            ->expects($this->once())
+            ->method('generate')
+            ->with(
+                $this->equalTo('browse_route'),
+                $this->equalTo(array('foo' => 'bar')),
+                $this->equalTo(true)
+            )
+            ->will($this->returnValue('browse_url'));
+
+        $this->configManager->setConfig(
+            'foo',
+            array(
+                'filebrowser'.$filebrowser.'Handler' => function (RouterInterface $router) {
+                    return $router->generate('browse_route', array('foo' => 'bar'), true);
+                },
             )
         );
 


### PR DESCRIPTION
This PR solves #69 in a different way. Instead of propagated the current request attributes, we can now define a file browser closure:

``` php
$builder->add('field', 'ckeditor', array(
    'config' => array(
        'filebrowserBrowseHandler' => function (RouterInterface $router) use ($request) {
            // The router is always passed as argument.
            // Return your url according to the router/request or any other objects.
        },
    ),
));
```
