### PR TITLE
"contentsCss" url generation bugfix

### DIFF
--- a/Model/ConfigManager.php
+++ b/Model/ConfigManager.php
@@ -37,6 +37,9 @@ class ConfigManager implements ConfigManagerInterface
 
     /** @var array */
     protected $configs;
+    
+    /** @var array */
+    protected $generatedAssetsUrls = [];
 
     /**
      * Creates a CKEditor config manager.
@@ -223,9 +226,16 @@ class ConfigManager implements ConfigManagerInterface
 
             $config['contentsCss'] = array();
             foreach ($cssContents as $cssContent) {
-                $config['contentsCss'][] = $this->assetsVersionTrimerHelper->trim(
-                    $this->assetsHelper->getUrl($cssContent)
-                );
+                if (in_array($cssContent, $this->generatedAssetsUrls)) {
+                    $config['contentsCss'][] = $cssContent;
+                } else {
+                    $generatedCssContent = $this->assetsVersionTrimerHelper->trim(
+                        $this->assetsHelper->getUrl($cssContent)
+                    );
+                    
+                    $this->generatedAssetsUrls[$cssContent] = $generatedCssContent;
+                    $config['contentsCss'][]                = $generatedCssContent;
+                }
             }
         }
 


### PR DESCRIPTION
We are using the following settings in the `config.yml` :

```
templating:
    assets_version: 12345
    assets_version_format: v-%%2$s/%%1$s
```

The original metod generated wrong css content urls.
