### PR TITLE
[stylesSet] register only if isn't already registered.

### DIFF
--- a/Helper/CKEditorHelper.php
+++ b/Helper/CKEditorHelper.php
@@ -168,7 +168,7 @@ EOF;
      */
     public function renderStylesSet($name, array $stylesSet)
     {
-        return sprintf('CKEDITOR.stylesSet.add("%s", %s);', $name, json_encode($stylesSet));
+        return sprintf('if (null === CKEDITOR.stylesSet.get("%s")) { CKEDITOR.stylesSet.add("%s", %s); }', $name, $name, json_encode($stylesSet));
     }
 
     /**


### PR DESCRIPTION
When I use multiple fields ckeditor in the same form, it gives me an error in js:

```
Uncaught [CKEDITOR.resourceManager.add] The resource name "default" is already registered. 
```

config.yml:

```
ivory_ck_editor:
    default_config: admin_config
    configs:
        admin_config:
            styles: default
    styles:
        default:
            - { name: "Blue Title", element: "h2", styles: { color: "Blue" }}
```
