### PR TITLE
Allow RegExp by relying on egeloen/json-builder

### DIFF
--- a/Tests/Helper/CKEditorHelperTest.php
+++ b/Tests/Helper/CKEditorHelperTest.php
@@ -221,6 +221,39 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRenderReplaceWithProtectedSource()
+    {
+        $this->assertSame(
+            'CKEDITOR.replace("foo", {"protectedSource":[/<\?[\s\S]*?\?>/g,/<%[\s\S]*?%>/g]});',
+            $this->helper->renderReplace('foo', array(
+                'protectedSource' => array(
+                    '/<\?[\s\S]*?\?>/g',
+                    '/<%[\s\S]*?%>/g',
+                )
+            ))
+        );
+    }
+
+    public function testRenderReplaceWithStylesheetParserSkipSelectors()
+    {
+        $this->assertSame(
+            'CKEDITOR.replace("foo", {"stylesheetParser_skipSelectors":/(^body\.|^caption\.|\.high|^\.)/i});',
+            $this->helper->renderReplace('foo', array(
+                'stylesheetParser_skipSelectors' => '/(^body\.|^caption\.|\.high|^\.)/i',
+            ))
+        );
+    }
+
+    public function testRenderReplaceWithStylesheetParserValidSelectors()
+    {
+        $this->assertSame(
+            'CKEDITOR.replace("foo", {"stylesheetParser_validSelectors":/\^(p|span)\.\w+/});',
+            $this->helper->renderReplace('foo', array(
+                'stylesheetParser_validSelectors' => '/\^(p|span)\.\w+/',
+            ))
+        );
+    }
+
     public function testRenderReplaceWithCKEditorConstants()
     {
         $this->assertSame(
@@ -236,13 +269,10 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderDestroy()
     {
-        $expected = <<<EOF
-if (CKEDITOR.instances["foo"]) {
-    delete CKEDITOR.instances["foo"];
-}
-EOF;
-
-        $this->assertSame($expected, $this->helper->renderDestroy('foo'));
+        $this->assertSame(
+            'if (CKEDITOR.instances["foo"]) { delete CKEDITOR.instances["foo"]; }',
+            $this->helper->renderDestroy('foo')
+        );
     }
 
     public function testRenderPlugin()

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle": ">=2.1",
-        "symfony/form": ">=2.1"
+        "symfony/framework-bundle": "~2.1",
+        "symfony/form": "~2.1",
+        "egeloen/json-builder": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
-        "twig/twig": "1.*"
+        "phpunit/phpunit": "~3.7",
+        "twig/twig": "~1.0"
     },
     "suggest": {
         "twig/twig": "Allows to use Ivory CKEditor twig templates",
@@ -32,7 +33,7 @@
     "target-dir": "Ivory/CKEditorBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "2.3-dev"
         }
     }
 }


### PR DESCRIPTION
This PR fixes #100 by relying on the egeloen/json-builder library in order to keep control of the JSON escaping strategy.
