### PR TITLE
Add onchange updateElement if the editor is embedded

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -245,6 +245,7 @@ class CKEditorType extends AbstractType
 
         if ($builder->getAttribute('enable')) {
             $builder->setAttribute('autoload', $options['autoload']);
+            $builder->setAttribute('embedded', $options['embedded']);
             $builder->setAttribute('base_path', $options['base_path']);
             $builder->setAttribute('js_path', $options['js_path']);
 
@@ -278,6 +279,7 @@ class CKEditorType extends AbstractType
 
         if ($form->getConfig()->getAttribute('enable')) {
             $view->vars['autoload'] = $form->getConfig()->getAttribute('autoload');
+            $view->vars['embedded'] = $form->getConfig()->getAttribute('embedded');
             $view->vars['base_path'] = $form->getConfig()->getAttribute('base_path');
             $view->vars['js_path'] = $form->getConfig()->getAttribute('js_path');
             $view->vars['config'] = $form->getConfig()->getAttribute('config');
@@ -296,6 +298,7 @@ class CKEditorType extends AbstractType
             ->setDefaults(array(
                 'enable'      => $this->enable,
                 'autoload'    => $this->autoload,
+                'embedded'    => false,
                 'base_path'   => $this->basePath,
                 'js_path'     => $this->jsPath,
                 'config_name' => $this->configManager->getDefaultConfig(),
@@ -307,6 +310,7 @@ class CKEditorType extends AbstractType
             ->addAllowedTypes(array(
                 'enable'      => 'bool',
                 'autoload'    => 'bool',
+                'embedded'    => 'bool',
                 'config_name' => array('string', 'null'),
                 'base_path'   => array('string'),
                 'js_path'     => array('string'),

--- a/Resources/views/Form/ckeditor_widget.html.php
+++ b/Resources/views/Form/ckeditor_widget.html.php
@@ -22,6 +22,6 @@
             <?php echo $view['ivory_ckeditor']->renderTemplate($templateName, $template); ?>
         <?php endforeach; ?>
 
-        <?php echo $view['ivory_ckeditor']->renderReplace($id, $config); ?>
+        <?php echo $view['ivory_ckeditor']->renderReplace($id, $config, $embedded); ?>
     </script>
 <?php endif; ?>

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -23,7 +23,7 @@
                 {{ ckeditor_template(template_name, template) }}
             {% endfor %}
 
-            {{ ckeditor_replace(id, config) }}
+            {{ ckeditor_replace(id, config, embedded) }}
         </script>
     {% endif %}
 {% endblock %}

--- a/Templating/CKEditorHelper.php
+++ b/Templating/CKEditorHelper.php
@@ -66,12 +66,13 @@ class CKEditorHelper extends Helper
     /**
      * Renders the replace.
      *
-     * @param string $id     The identifier.
-     * @param array  $config The config.
+     * @param string  $id       The identifier.
+     * @param array   $config   The config.
+     * @param boolean $embedded Is the editor embedded?
      *
      * @return string The rendered replace.
      */
-    public function renderReplace($id, array $config)
+    public function renderReplace($id, array $config, $embedded = false)
     {
         $this->jsonBuilder
             ->reset()
@@ -79,7 +80,18 @@ class CKEditorHelper extends Helper
 
         $this->fixConfigEscapedValues($config);
 
-        return sprintf('CKEDITOR.replace("%s", %s);', $id, $this->fixConfigConstants($this->jsonBuilder->build()));
+        $js = sprintf(
+            'CKEDITOR.replace("%s", %s);',
+            $id,
+            $this->fixConfigConstants($this->jsonBuilder->build())
+        );
+
+        if ($embedded) {
+            $name = 'editor_' . $id;
+            $js = "var $name = $js $name.on('change', function() { $name.updateElement() });";
+        }
+
+        return $js;
     }
 
     /**

--- a/Twig/CKEditorExtension.php
+++ b/Twig/CKEditorExtension.php
@@ -78,14 +78,15 @@ class CKEditorExtension extends \Twig_Extension
     /**
      * Renders the replace.
      *
-     * @param string $id     The identifier.
-     * @param array  $config The config.
+     * @param string  $id       The identifier.
+     * @param array   $config   The config.
+     * @param boolean $embedded Is the editor embedded?
      *
      * @return string The rendered replace.
      */
-    public function renderReplace($id, array $config)
+    public function renderReplace($id, array $config, $embedded = false)
     {
-        return $this->helper->renderReplace($id, $config);
+        return $this->helper->renderReplace($id, $config, $embedded);
     }
 
     /**


### PR DESCRIPTION
If the editor is embedded in a page through ajax the content is not saved.

This PR adds an option to add onchange updateElement to the javascript output

Usage:

``` php
$builder->add('field', 'ckeditor', array('embedded' => true));
```
