### PR TITLE
Fix SonataMedia integration package name

### DIFF
--- a/Resources/doc/file_browse_upload.md
+++ b/Resources/doc/file_browse_upload.md
@@ -137,7 +137,7 @@ Add CoopTilleulsCKEditorSonataMediaBundle in your `composer.json` file:
 ``` json
 {
     "require": {
-        "tilleuls/ckeditor-sonata-mediabundle": "~1.0",
+        "tilleuls/ckeditor-sonata-media-bundle": "~1.0",
     }
 }
 ```


### PR DESCRIPTION
There's a typo in the name of package `tilleuls/ckeditor-sonata-media-bundle`.
