### PR TITLE
add custom asset helper to work with symfony 2.7

### DIFF
--- a/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Create assets.packages fallback alias for symfony < 2.7
+ *
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
+ */
+class AssetsHelperCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('assets.packages')) {
+            return;
+        }
+
+        if (!$container->hasDefinition('templating.helper.assets')) {
+            throw new ServiceNotFoundException('templating.helper.assets');
+        }
+
+        // create fallback alias for symfony < 2.7
+        $container->setAlias('assets.packages', 'templating.helper.assets');
+    }
+}

--- a/IvoryCKEditorBundle.php
+++ b/IvoryCKEditorBundle.php
@@ -12,12 +12,22 @@
 namespace Ivory\CKEditorBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Ivory\CKEditorBundle\DependencyInjection\Compiler;
 
 /**
  * Ivory CKEditor bundle.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 class IvoryCKEditorBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new Compiler\AssetsHelperCompilerPass());
+    }
 }

--- a/Templating/CKEditorHelper.php
+++ b/Templating/CKEditorHelper.php
@@ -19,6 +19,7 @@ use Symfony\Component\Templating\Helper\Helper;
  * CKEditor helper.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 class CKEditorHelper extends Helper
 {
@@ -323,11 +324,11 @@ class CKEditorHelper extends Helper
     /**
      * Gets the assets helper.
      *
-     * @return \Symfony\Component\Templating\Helper\CoreAssetsHelper The assets helper.
+     * @return \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper The assets helper.
      */
     private function getAssetsHelper()
     {
-        return $this->container->get('templating.helper.assets');
+        return $this->container->get('assets.packages');
     }
 
     /**

--- a/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
@@ -19,13 +19,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * Abstract Ivory CKEditor extension test.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_TestCase
 {
     /** @var \Symfony\Component\DependencyInjection\ContainerBuilder */
     private $container;
 
-    /** @var \Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
     private $assetsHelperMock;
 
     /** @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject */
@@ -36,15 +37,21 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
      */
     protected function setUp()
     {
-        $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        if (class_exists('Symfony\Component\Asset\Packages')) {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Asset\Packages')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
         $this->routerMock = $this->getMock('Symfony\Component\Routing\RouterInterface');
 
         $this->container = new ContainerBuilder();
 
-        $this->container->set('templating.helper.assets', $this->assetsHelperMock);
+        $this->container->set('assets.packages', $this->assetsHelperMock);
         $this->container->set('router', $this->routerMock);
 
         $this->container->registerExtension($framework = new FrameworkExtension());
@@ -329,6 +336,15 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
 
         $this->assertSame('foo', $ckEditorType->getBasePath());
         $this->assertSame('foo/ckeditor.js', $ckEditorType->getJsPath());
+    }
+
+    public function testTemplatingConfiguration()
+    {
+        $this->container->compile();
+
+        $helper = $this->container->get('ivory_ck_editor.templating.helper');
+
+        $this->assertInstanceOf('Ivory\CKEditorBundle\Templating\CKEditorHelper', $helper);
     }
 
     /**

--- a/Tests/DependencyInjection/Compiler/AssetsHelperCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AssetsHelperCompilerPassTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\DependencyInjection\Compiler;
+
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Assets helper compiler pass test.
+ *
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
+ */
+class AssetsHelperCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
+    private $containerBuilderMock;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('hasDefinition', 'setAlias'))
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->containerBuilderMock);
+    }
+
+    public function testAssetsPackagesExists()
+    {
+        $this->containerBuilderMock
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('assets.packages')
+            ->will($this->returnValue(true));
+
+        $compilerPass = new AssetsHelperCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+
+    public function testAssetsPackagesNotExists()
+    {
+        $this->containerBuilderMock
+            ->expects($this->at(0))
+            ->method('hasDefinition')
+            ->with('assets.packages')
+            ->will($this->returnValue(false));
+
+        $this->containerBuilderMock
+            ->expects($this->at(1))
+            ->method('hasDefinition')
+            ->with('templating.helper.assets')
+            ->will($this->returnValue(true));
+
+        $this->containerBuilderMock
+            ->expects($this->once())
+            ->method('setAlias')
+            ->with($this->equalTo('assets.packages'), $this->equalTo('templating.helper.assets'));
+
+        $compilerPass = new AssetsHelperCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage You have requested a non-existent service "templating.helper.assets".
+     */
+    public function testMissingService()
+    {
+        $this->containerBuilderMock
+            ->expects($this->at(0))
+            ->method('hasDefinition')
+            ->with('assets.packages')
+            ->will($this->returnValue(false));
+
+        $this->containerBuilderMock
+            ->expects($this->at(1))
+            ->method('hasDefinition')
+            ->with('templating.helper.assets')
+            ->will($this->returnValue(false));
+
+        $compilerPass = new AssetsHelperCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+}

--- a/Tests/IvoryCKEditorBundleTest.php
+++ b/Tests/IvoryCKEditorBundleTest.php
@@ -17,6 +17,7 @@ use Ivory\CKEditorBundle\IvoryCKEditorBundle;
  * Ivory CKEditor bundle test.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 class IvoryCKEditorBundleTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,5 +26,22 @@ class IvoryCKEditorBundleTest extends \PHPUnit_Framework_TestCase
         $bundle = new IvoryCKEditorBundle();
 
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Bundle\Bundle', $bundle);
+    }
+
+    public function testAddAssetHelperCompilerPassOnBuild()
+    {
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('addCompilerPass'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $containerMock
+            ->expects($this->once())
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass'));
+
+        $bundle = new IvoryCKEditorBundle();
+
+        $bundle->build($containerMock);
     }
 }

--- a/Tests/Template/AbstractTemplateTest.php
+++ b/Tests/Template/AbstractTemplateTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Abstract template test.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,7 +28,7 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $containerMock;
 
-    /** @var \Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
     private $assetsHelperMock;
 
     /** @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject */
@@ -40,9 +41,15 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
     {
         $this->routerMock = $this->getMock('Symfony\Component\Routing\RouterInterface');
 
-        $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        if (class_exists('Symfony\Component\Asset\Packages')) {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Asset\Packages')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
         $this->assetsHelperMock
             ->expects($this->any())
@@ -55,7 +62,7 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValueMap(array(
                 array(
-                    'templating.helper.assets',
+                    'assets.packages',
                     ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
                     $this->assetsHelperMock,
                 ),

--- a/Tests/Templating/CKEditorHelperTest.php
+++ b/Tests/Templating/CKEditorHelperTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Routing\RouterInterface;
  * CKEditor helper test.
  *
  * @author GeLo <geloen.eric@gmail.com>
+ * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
 class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +29,7 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $containerMock;
 
-    /** @var \Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
     private $assetsHelperMock;
 
     /** @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject */
@@ -39,9 +40,15 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        if (class_exists('Symfony\Component\Asset\Packages')) {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Asset\Packages')
+                ->disableOriginalConstructor()
+                ->getMock();
+        } else {
+            $this->assetsHelperMock = $this->getMockBuilder('Symfony\Component\Templating\Helper\CoreAssetsHelper')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
 
         $this->routerMock = $this->getMock('Symfony\Component\Routing\RouterInterface');
 
@@ -51,7 +58,7 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValueMap(array(
                 array(
-                    'templating.helper.assets',
+                    'assets.packages',
                     ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
                     $this->assetsHelperMock,
                 ),


### PR DESCRIPTION
Hi,

Since symfony 2.7 service `templating.helper.assets` is depricated (https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Templating/Helper/CoreAssetsHelper.php#L14) and `assets.packages` comes for it's replacement. 

That is why i added new `ivory_ck_editor.templating.asset_helper` service which can get asset url for symfony < 2.7 from `templating.helper.assets` and symfony 2.7 from `assets.packages`.
