### PR TITLE
Don't inject the complete DIC

### DIFF
--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -6,7 +6,8 @@
 >
     <services>
         <service id="ivory_ck_editor.templating.helper" class="Ivory\CKEditorBundle\Templating\CKEditorHelper">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="router" />
+            <argument type="service" id="templating.helper.assets" />
             <tag name="templating.helper" alias="ivory_ckeditor" />
         </service>
     </services>

--- a/Templating/CKEditorHelper.php
+++ b/Templating/CKEditorHelper.php
@@ -12,8 +12,9 @@
 namespace Ivory\CKEditorBundle\Templating;
 
 use Ivory\JsonBuilder\JsonBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Templating\Helper\Helper;
+use Symfony\Component\Templating\Helper\HelperInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * CKEditor helper.
@@ -25,18 +26,23 @@ class CKEditorHelper extends Helper
     /** @var \Ivory\JsonBuilder\JsonBuilder */
     private $jsonBuilder;
 
-    /** @var \Symfony\Component\DependencyInjection\ContainerInterface */
-    private $container;
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    /** @var \Symfony\Component\Templating\Helper\HelperInterface */
+    private $assetHelper;
 
     /**
      * Creates a CKEditor template helper.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container The container.
+     * @param Symfony\Component\Routing\RouterInterface The router.
+     * @param Symfony\Component\Templating\Helper\HelperInterface The asset helper
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(RouterInterface $router, HelperInterface $helper)
     {
         $this->jsonBuilder = new JsonBuilder();
-        $this->container = $container;
+        $this->router      = $router;
+        $this->assetHelper = $helper;
     }
 
     /**
@@ -327,7 +333,7 @@ class CKEditorHelper extends Helper
      */
     private function getAssetsHelper()
     {
-        return $this->container->get('templating.helper.assets');
+        return $this->assetHelper;
     }
 
     /**
@@ -337,6 +343,6 @@ class CKEditorHelper extends Helper
      */
     private function getRouter()
     {
-        return $this->container->get('router');
+        return $this->router;
     }
 }

--- a/Tests/Template/AbstractTemplateTest.php
+++ b/Tests/Template/AbstractTemplateTest.php
@@ -24,9 +24,6 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
     /** @var \Ivory\CKEditorBundle\Templating\CKEditorHelper */
     protected $helper;
 
-    /** @var \Symfony\Component\DependencyInjection\ContainerInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $containerMock;
-
     /** @var \Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
     private $assetsHelperMock;
 
@@ -49,24 +46,7 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
             ->method('getUrl')
             ->will($this->returnArgument(0));
 
-        $this->containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->containerMock
-            ->expects($this->any())
-            ->method('get')
-            ->will($this->returnValueMap(array(
-                array(
-                    'templating.helper.assets',
-                    ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                    $this->assetsHelperMock,
-                ),
-                array(
-                    'router',
-                    ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                    $this->routerMock,
-                ),
-            )));
-
-        $this->helper = new CKEditorHelper($this->containerMock);
+        $this->helper = new CKEditorHelper($this->routerMock, $this->assetsHelperMock);
     }
 
     /**
@@ -76,7 +56,6 @@ abstract class AbstractTemplateTest extends \PHPUnit_Framework_TestCase
     {
         unset($this->routerMock);
         unset($this->assetsHelperMock);
-        unset($this->containerMock);
         unset($this->helper);
     }
 

--- a/Tests/Templating/CKEditorHelperTest.php
+++ b/Tests/Templating/CKEditorHelperTest.php
@@ -25,9 +25,6 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
     /** @var \Ivory\CKEditorBundle\Templating\CKEditorHelper */
     private $helper;
 
-    /** @var \Symfony\Component\DependencyInjection\ContainerInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $containerMock;
-
     /** @var \Symfony\Component\Templating\Helper\CoreAssetsHelper|\PHPUnit_Framework_MockObject_MockObject */
     private $assetsHelperMock;
 
@@ -45,24 +42,7 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->routerMock = $this->getMock('Symfony\Component\Routing\RouterInterface');
 
-        $this->containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->containerMock
-            ->expects($this->any())
-            ->method('get')
-            ->will($this->returnValueMap(array(
-                array(
-                    'templating.helper.assets',
-                    ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                    $this->assetsHelperMock,
-                ),
-                array(
-                    'router',
-                    ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                    $this->routerMock,
-                ),
-            )));
-
-        $this->helper = new CKEditorHelper($this->containerMock);
+        $this->helper = new CKEditorHelper($this->routerMock, $this->assetsHelperMock);
     }
 
     /**
@@ -71,7 +51,6 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         unset($this->helper);
-        unset($this->containerMock);
         unset($this->routerMock);
         unset($this->assetsHelperMock);
     }


### PR DESCRIPTION
I'm fairly certain its bad practice to inject the entire DIC into a service
unless you have issues with circular dependencies or other issues. Therefore
the CKEditorHelper has been refactored to have the router and template asset
helper injected directly.