### PR TITLE
Use new way of adding form allowed types for symfony >= 2.6

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * CKEditor type.
@@ -384,21 +385,31 @@ class CKEditorType extends AbstractType
                 'styles'      => array(),
                 'templates'   => array(),
             ))
-            ->addAllowedTypes(array(
-                'enable'      => 'bool',
-                'autoload'    => 'bool',
-                'inline'      => 'bool',
-                'jquery'      => 'bool',
-                'input_sync'  => 'bool',
-                'config_name' => array('string', 'null'),
-                'base_path'   => 'string',
-                'js_path'     => 'string',
-                'jquery_path' => 'string',
-                'config'      => 'array',
-                'plugins'     => 'array',
-                'styles'      => 'array',
-                'templates'   => 'array',
-            ));
+        ;
+
+        $allowedTypesMap = array(
+            'enable'      => 'bool',
+            'autoload'    => 'bool',
+            'inline'      => 'bool',
+            'jquery'      => 'bool',
+            'input_sync'  => 'bool',
+            'config_name' => array('string', 'null'),
+            'base_path'   => 'string',
+            'js_path'     => 'string',
+            'jquery_path' => 'string',
+            'config'      => 'array',
+            'plugins'     => 'array',
+            'styles'      => 'array',
+            'templates'   => 'array',
+        );
+
+        if (Kernel::VERSION_ID >= 20600) {
+             foreach ($allowedTypesMap as $option => $allowedTypes) {
+                 $resolver->addAllowedTypes($option, $allowedTypes);
+             }
+        } else {
+            $resolver->addAllowedTypes($allowedTypesMap);
+        }
     }
 
     /**


### PR DESCRIPTION
Since symfony 2.6 there is a new way of adding allowed types to `OptionsResolver` (https://github.com/symfony/symfony/blob/2.6/src/Symfony/Component/OptionsResolver/OptionsResolver.php#L620) and old one has been deprecated in 2.7 (https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/OptionsResolver/OptionsResolver.php#L642)
