### PR TITLE
Move resources merging in a compiler pass

### DIFF
--- a/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
@@ -11,7 +11,6 @@
 
 namespace Ivory\CKEditorBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -23,6 +22,9 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  */
 class AssetsHelperCompilerPass implements CompilerPassInterface
 {
+    /**
+     * {@inheritdoc}
+     */
     public function process(ContainerBuilder $container)
     {
         if ($container->hasDefinition('assets.packages')) {

--- a/DependencyInjection/Compiler/ResourceCompilerPass.php
+++ b/DependencyInjection/Compiler/ResourceCompilerPass.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Resource compiler pass.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class ResourceCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $templatingEngines = $container->getParameter('templating.engines');
+
+        if (in_array('php', $templatingEngines)) {
+            $container->setParameter(
+                'templating.helper.form.resources',
+                array_merge(
+                    array('IvoryCKEditorBundle:Form'),
+                    $container->getParameter('templating.helper.form.resources')
+                )
+            );
+        }
+
+        if (in_array('twig', $templatingEngines)) {
+            $container->setParameter(
+                'twig.form.resources',
+                array_merge(
+                    array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig'),
+                    $container->getParameter('twig.form.resources')
+                )
+            );
+        }
+    }
+}

--- a/DependencyInjection/IvoryCKEditorExtension.php
+++ b/DependencyInjection/IvoryCKEditorExtension.php
@@ -34,7 +34,6 @@ class IvoryCKEditorExtension extends ConfigurableExtension
             $loader->load($service.'.xml');
         }
 
-        $this->registerResources($container);
         $this->registerConfig($config, $container);
 
         if (!isset($config['enable']) || $config['enable']) {
@@ -42,36 +41,6 @@ class IvoryCKEditorExtension extends ConfigurableExtension
             $this->registerPlugins($config, $container);
             $this->registerStylesSet($config, $container);
             $this->registerTemplates($config, $container);
-        }
-    }
-
-    /**
-     * Registers the form resources for the PHP/Twig templating engines.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container The container.
-     */
-    private function registerResources(ContainerBuilder $container)
-    {
-        $templatingEngines = $container->getParameter('templating.engines');
-
-        if (in_array('php', $templatingEngines)) {
-            $container->setParameter(
-                'templating.helper.form.resources',
-                array_merge(
-                    array('IvoryCKEditorBundle:Form'),
-                    $container->getParameter('templating.helper.form.resources')
-                )
-            );
-        }
-
-        if (in_array('twig', $templatingEngines)) {
-            $container->setParameter(
-                'twig.form.resources',
-                array_merge(
-                    array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig'),
-                    $container->getParameter('twig.form.resources')
-                )
-            );
         }
     }
 

--- a/IvoryCKEditorBundle.php
+++ b/IvoryCKEditorBundle.php
@@ -11,9 +11,10 @@
 
 namespace Ivory\CKEditorBundle;
 
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass;
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Ivory\CKEditorBundle\DependencyInjection\Compiler;
 
 /**
  * Ivory CKEditor bundle.
@@ -28,6 +29,8 @@ class IvoryCKEditorBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new Compiler\AssetsHelperCompilerPass());
+        $container
+            ->addCompilerPass(new ResourceCompilerPass())
+            ->addCompilerPass(new AssetsHelperCompilerPass());
     }
 }

--- a/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\CKEditorBundle\Tests\DependencyInjection;
 
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass;
 use Ivory\CKEditorBundle\DependencyInjection\IvoryCKEditorExtension;
 use Ivory\CKEditorBundle\Tests\Fixtures\Extension\FrameworkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -98,27 +99,6 @@ abstract class AbstractIvoryCKEditorExtensionTest extends \PHPUnit_Framework_Tes
         $this->assertSame($this->container->get('ivory_ck_editor.plugin_manager'), $type->getPluginManager());
         $this->assertSame($this->container->get('ivory_ck_editor.styles_set_manager'), $type->getStylesSetManager());
         $this->assertSame($this->container->get('ivory_ck_editor.template_manager'), $type->getTemplateManager());
-    }
-
-    public function testTwigResources()
-    {
-        $this->container->compile();
-
-        $this->assertTrue(
-            in_array(
-                'IvoryCKEditorBundle:Form:ckeditor_widget.html.twig',
-                $this->container->getParameter('twig.form.resources')
-            )
-        );
-    }
-
-    public function testPhpResources()
-    {
-        $this->container->compile();
-
-        $this->assertTrue(
-            in_array('IvoryCKEditorBundle:Form', $this->container->getParameter('templating.helper.form.resources'))
-        );
     }
 
     public function testDisable()

--- a/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\DependencyInjection\Compiler;
+
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass;
+
+/**
+ * Resource compiler pass test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class ResourceCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass */
+    private $compilerPass;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->compilerPass = new ResourceCompilerPass();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->compilerPass);
+    }
+
+    public function testTwigResource()
+    {
+        $containerBuilder = $this->createContainerBuilderMock();
+        $containerBuilder
+            ->expects($this->any())
+            ->method('getParameter')
+            ->will($this->returnValueMap(array(
+                array('templating.engines', array('twig')),
+                array($parameter = 'twig.form.resources', array($template = 'foo')),
+            )));
+
+        $containerBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                $this->identicalTo($parameter),
+                $this->identicalTo(array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig', $template))
+            );
+
+        $this->compilerPass->process($containerBuilder);
+    }
+
+    public function testPhpResource()
+    {
+        $containerBuilder = $this->createContainerBuilderMock();
+        $containerBuilder
+            ->expects($this->any())
+            ->method('getParameter')
+            ->will($this->returnValueMap(array(
+                array('templating.engines', array('php')),
+                array($parameter = 'templating.helper.form.resources', array($template = 'foo')),
+            )));
+
+        $containerBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                $this->identicalTo($parameter),
+                $this->identicalTo(array('IvoryCKEditorBundle:Form', $template))
+            );
+
+        $this->compilerPass->process($containerBuilder);
+    }
+
+    /**
+     * Creates a container builder mock.
+     *
+     * @return \Symfony\Component\DependencyInjection\ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createContainerBuilderMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getParameter', 'setParameter'))
+            ->getMock();
+    }
+}

--- a/Tests/IvoryCKEditorBundleTest.php
+++ b/Tests/IvoryCKEditorBundleTest.php
@@ -28,20 +28,26 @@ class IvoryCKEditorBundleTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpKernel\Bundle\Bundle', $bundle);
     }
 
-    public function testAddAssetHelperCompilerPassOnBuild()
+    public function testCompilerPasses()
     {
-        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(array('addCompilerPass'))
+        $containerBuilder = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
             ->disableOriginalConstructor()
+            ->setMethods(array('addCompilerPass'))
             ->getMock();
 
-        $containerMock
-            ->expects($this->once())
+        $containerBuilder
+            ->expects($this->at(0))
             ->method('addCompilerPass')
-            ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass'));
+            ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass'))
+            ->will($this->returnSelf());
+
+        $containerBuilder
+            ->expects($this->at(1))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass'))
+            ->will($this->returnSelf());
 
         $bundle = new IvoryCKEditorBundle();
-
-        $bundle->build($containerMock);
+        $bundle->build($containerBuilder);
     }
 }


### PR DESCRIPTION
All is in the title. That will drop issues with the bundle registration ordering.