### PR TITLE
Added new block "ckeditor_config_start" for CKEditor custom initialization code 

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -12,6 +12,8 @@
             {% endif %}
         {% endif %}
         <script type="text/javascript">
+            {% block ckeditor_config_start %}{% endblock %}
+        
             {{ ckeditor_destroy(id) }}
 
             {% for plugin_name, plugin in plugins %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

Use case: I would like to modify CKEDITOR.env.isCompatible parametrer to enable CKeditor on Chrome for Android and maybe some other android browsers that will work good enough for our needs.