### PR TITLE
Add support for Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,12 @@ matrix:
           env: SYMFONY_VERSION=2.7.*
         - php: 5.6
           env: SYMFONY_VERSION=2.8.*@dev
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*@dev
     allow_failures:
         - php: 7.0
         - env: SYMFONY_VERSION=2.8.*@dev
+        - env: SYMFONY_VERSION=3.0.*@dev
 
 notifications:
     email: geloen.eric@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
 env:
     global:
         - COMPOSER_PREFER_LOWEST=false
+        - SYMFONY_DEPRECATIONS_HELPER=weak
         - SYMFONY_VERSION=2.3.*
 
 cache:
@@ -23,6 +24,7 @@ install:
     - composer self-update
     - composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
     - composer require --no-update symfony/form:${SYMFONY_VERSION}
+    - if [[ "$SYMFONY_VERSION" = "2.8.*@dev" ]] || [[ "$SYMFONY_VERSION" = "3.0.*@dev" ]]; then composer require --dev --no-update symfony/phpunit-bridge:${SYMFONY_VERSION}; fi
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
     - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`
 
@@ -45,13 +47,13 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
         - php: 5.6
-          env: SYMFONY_VERSION=2.8.*@dev
+          env: SYMFONY_VERSION=2.8.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
         - php: 5.6
-          env: SYMFONY_VERSION=3.0.*@dev
+          env: SYMFONY_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
     allow_failures:
         - php: 7.0
-        - env: SYMFONY_VERSION=2.8.*@dev
-        - env: SYMFONY_VERSION=3.0.*@dev
+        - env: SYMFONY_VERSION=2.8.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
+        - env: SYMFONY_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
 
 notifications:
     email: geloen.eric@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
     - composer self-update
     - composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
     - composer require --no-update symfony/form:${SYMFONY_VERSION}
-    - if [[ "$SYMFONY_VERSION" = "2.8.*@dev" ]] || [[ "$SYMFONY_VERSION" = "3.0.*@dev" ]]; then composer require --dev --no-update symfony/phpunit-bridge:${SYMFONY_VERSION}; fi
+    - if [[ "$SYMFONY_VERSION" = "3.0.*" ]]; then composer require --dev --no-update symfony/phpunit-bridge:${SYMFONY_VERSION}; fi
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
     - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`
 
@@ -47,13 +47,11 @@ matrix:
         - php: 5.6
           env: SYMFONY_VERSION=2.7.*
         - php: 5.6
-          env: SYMFONY_VERSION=2.8.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
+          env: SYMFONY_VERSION=2.8.* SYMFONY_DEPRECATIONS_HELPER=strict
         - php: 5.6
-          env: SYMFONY_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
+          env: SYMFONY_VERSION=3.0.* SYMFONY_DEPRECATIONS_HELPER=strict
     allow_failures:
         - php: 7.0
-        - env: SYMFONY_VERSION=2.8.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
-        - env: SYMFONY_VERSION=3.0.*@dev SYMFONY_DEPRECATIONS_HELPER=strict
 
 notifications:
     email: geloen.eric@gmail.com

--- a/DependencyInjection/Compiler/FormTypeCompilerPass.php
+++ b/DependencyInjection/Compiler/FormTypeCompilerPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Create form.type tag alias for Symfony 2.x
+ */
+class FormTypeCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (Kernel::VERSION_ID >= 30000) {
+            return;
+        }
+
+        if (!$container->hasDefinition('ivory_ck_editor.form.type')) {
+            throw new ServiceNotFoundException('ivory_ck_editor.form.type');
+        }
+
+        $definition = $container->getDefinition('ivory_ck_editor.form.type');
+        $definition->clearTag('form.type');
+        $definition->addTag('form.type', array('alias' => 'ckeditor'));
+    }
+}

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -453,7 +453,7 @@ class CKEditorType extends AbstractType
     public function getParent()
     {
         if (Kernel::VERSION_ID >= 20800) {
-            return 'Symfony\Component\Form\Extension\Core\Type\TextAreaType';
+            return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
         }
 
         return 'textarea';

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -452,10 +452,12 @@ class CKEditorType extends AbstractType
      */
     public function getParent()
     {
-        if (Kernel::VERSION_ID >= 20800) {
+        // Prefer the FQCN if the getBlockPrefix method exists on the parent method
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
             return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
         }
 
+        // Return the legacy shortname; drop this when Symfony <2.8 support is removed
         return 'textarea';
     }
 

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -464,6 +464,14 @@ class CKEditorType extends AbstractType
      */
     public function getName()
     {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
         return 'ckeditor';
     }
 }

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -452,6 +452,10 @@ class CKEditorType extends AbstractType
      */
     public function getParent()
     {
+        if (Kernel::VERSION_ID >= 20800) {
+            return 'Symfony\Component\Form\Extension\Core\Type\TextAreaType';
+        }
+
         return 'textarea';
     }
 

--- a/IvoryCKEditorBundle.php
+++ b/IvoryCKEditorBundle.php
@@ -12,6 +12,7 @@
 namespace Ivory\CKEditorBundle;
 
 use Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass;
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\FormTypeCompilerPass;
 use Ivory\CKEditorBundle\DependencyInjection\Compiler\ResourceCompilerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -31,6 +32,7 @@ class IvoryCKEditorBundle extends Bundle
     {
         $container
             ->addCompilerPass(new ResourceCompilerPass())
-            ->addCompilerPass(new AssetsHelperCompilerPass());
+            ->addCompilerPass(new AssetsHelperCompilerPass())
+            ->addCompilerPass(new FormTypeCompilerPass());
     }
 }

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="ivory_ck_editor.plugin_manager" />
             <argument type="service" id="ivory_ck_editor.styles_set_manager" />
             <argument type="service" id="ivory_ck_editor.template_manager" />
-            <tag name="form.type" alias="ckeditor" />
+            <tag name="form.type" />
         </service>
 
         <service id="ivory_ck_editor.config_manager" class="Ivory\CKEditorBundle\Model\ConfigManager" />

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -31,6 +31,10 @@ $builder->add('field', 'ckeditor', array(
 ));
 ```
 
+**NOTE** As of Symfony 2.8, the second parameter for ``$builder->add()`` accepts the fully qualified class name of the
+form type and is required in Symfony 3.0. In these Symfony versions, you should replace the ``ckeditor`` parameter value
+with ``Ivory\CKEditorBundle\Form\Type\CKEditorType``.
+
 A toolbar is an array of toolbars (strips), each one being also an array, containing a list of UI items. To do a
 carriage return, you just have to add the char ``/`` between strips.
 

--- a/Tests/DependencyInjection/Compiler/FormTypeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FormTypeCompilerPassTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\DependencyInjection\Compiler;
+
+use Ivory\CKEditorBundle\DependencyInjection\Compiler\FormTypeCompilerPass;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Form type compiler pass test.
+ */
+class FormTypeCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Symfony\Component\DependencyInjection\ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject */
+    private $containerBuilderMock;
+
+    /** @var \Symfony\Component\DependencyInjection\Definition|\PHPUnit_Framework_MockObject_MockObject */
+    private $mockDefinition;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->containerBuilderMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->setMethods(array('getDefinition', 'hasDefinition'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockDefinition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->setMethods(array('addTag', 'clearTag'))
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->containerBuilderMock);
+        unset($this->mockDefinition);
+    }
+
+    public function testFormTypeAliasAddedForSymfony2()
+    {
+        // This test applies only to Symfony 2.x
+        if (Kernel::VERSION_ID >= 30000) {
+            $this->markTestSkipped('This test applies only to Symfony 2.x');
+        }
+
+        $this->mockDefinition
+            ->expects($this->once())
+            ->method('addTag')
+            ->with('form.type', array('alias' => 'ckeditor'))
+            ->will($this->returnSelf());
+
+        $this->mockDefinition
+            ->expects($this->once())
+            ->method('clearTag')
+            ->with('form.type')
+            ->will($this->returnSelf());
+
+        $this->containerBuilderMock
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with('ivory_ck_editor.form.type')
+            ->will($this->returnValue($this->mockDefinition));
+
+        $this->containerBuilderMock
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('ivory_ck_editor.form.type')
+            ->will($this->returnValue(true));
+
+        $compilerPass = new FormTypeCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+
+    public function testFormTypeAliasNotAddedForSymfony3()
+    {
+        // This test applies only to Symfony 3.x
+        if (Kernel::VERSION_ID < 30000) {
+            $this->markTestSkipped('This test applies only to Symfony 3.x');
+        }
+
+        $this->containerBuilderMock
+            ->expects($this->never())
+            ->method('hasDefinition')
+            ->with('ivory_ck_editor.form.type');
+
+        $compilerPass = new FormTypeCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessage You have requested a non-existent service "ivory_ck_editor.form.type".
+     */
+    public function testMissingServiceForSymfony2()
+    {
+        // This test applies only to Symfony 2.x
+        if (Kernel::VERSION_ID >= 30000) {
+            $this->markTestSkipped('This test applies only to Symfony 2.x');
+        }
+
+        $this->containerBuilderMock
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('ivory_ck_editor.form.type')
+            ->will($this->returnValue(false));
+
+        $compilerPass = new FormTypeCompilerPass();
+
+        $compilerPass->process($this->containerBuilderMock);
+    }
+}

--- a/Tests/Form/Type/CKEditorTypeTest.php
+++ b/Tests/Form/Type/CKEditorTypeTest.php
@@ -13,6 +13,7 @@ namespace Ivory\CKEditorBundle\Tests\Form\Type;
 
 use Ivory\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * CKEditor type test.
@@ -29,6 +30,9 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     /** @var \Ivory\CKEditorBundle\Model\ConfigManagerInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $configManagerMock;
+
+    /** @var string */
+    private $formType;
 
     /** @var \Ivory\CKEditorBundle\Model\PluginManagerInterface|\PHPUnit_Framework_MockObject_MockObject */
     private $pluginManagerMock;
@@ -59,6 +63,9 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
         $this->factory = Forms::createFormFactoryBuilder()
             ->addType($this->ckEditorType)
             ->getFormFactory();
+
+        // The form type requires a FQCN in Symfony 3.0 (feature added in Symfony 2.8)
+        $this->formType = Kernel::VERSION_ID >= 20800 ? 'Ivory\CKEditorBundle\Form\Type\CKEditorType' : 'ckeditor';
     }
 
     /**
@@ -93,7 +100,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('enable', $view->vars);
@@ -104,7 +111,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->isEnable(false);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('enable', $view->vars);
@@ -113,7 +120,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testEnableWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('enable' => false));
+        $form = $this->factory->create($this->formType, null, array('enable' => false));
         $view = $form->createView();
 
         $this->assertArrayHasKey('enable', $view->vars);
@@ -122,7 +129,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoloadWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('autoload', $view->vars);
@@ -133,7 +140,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->isAutoload(false);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('autoload', $view->vars);
@@ -142,7 +149,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoloadWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('autoload' => false));
+        $form = $this->factory->create($this->formType, null, array('autoload' => false));
         $view = $form->createView();
 
         $this->assertArrayHasKey('autoload', $view->vars);
@@ -151,7 +158,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoInlineWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('auto_inline', $view->vars);
@@ -162,7 +169,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->isAutoInline(false);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('auto_inline', $view->vars);
@@ -171,7 +178,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoInlineWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('auto_inline' => false));
+        $form = $this->factory->create($this->formType, null, array('auto_inline' => false));
         $view = $form->createView();
 
         $this->assertArrayHasKey('auto_inline', $view->vars);
@@ -180,7 +187,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testInlineWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('inline', $view->vars);
@@ -191,7 +198,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->isInline(true);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('inline', $view->vars);
@@ -200,7 +207,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testInlineWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('inline' => true));
+        $form = $this->factory->create($this->formType, null, array('inline' => true));
         $view = $form->createView();
 
         $this->assertArrayHasKey('inline', $view->vars);
@@ -209,7 +216,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testJqueryWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery', $view->vars);
@@ -220,7 +227,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->useJquery(true);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery', $view->vars);
@@ -229,7 +236,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testJqueryWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('jquery' => true));
+        $form = $this->factory->create($this->formType, null, array('jquery' => true));
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery', $view->vars);
@@ -238,7 +245,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testInputSyncWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('input_sync', $view->vars);
@@ -249,7 +256,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->isInputSync(true);
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('input_sync', $view->vars);
@@ -258,7 +265,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testInputSyncWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('input_sync' => true));
+        $form = $this->factory->create($this->formType, null, array('input_sync' => true));
         $view = $form->createView();
 
         $this->assertArrayHasKey('input_sync', $view->vars);
@@ -267,7 +274,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBaseAndJsPathWithDefaultValues()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('base_path', $view->vars);
@@ -281,7 +288,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->ckEditorType->setBasePath('foo/base/');
         $this->ckEditorType->setJsPath('foo/ckeditor.js');
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('base_path', $view->vars);
@@ -294,7 +301,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     public function testBaseAndJsPathWithExplicitValues()
     {
         $form = $this->factory->create(
-            'ckeditor',
+            $this->formType,
             null,
             array(
                 'base_path' => 'foo/',
@@ -313,7 +320,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testJqueryPathWithDefaultValue()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery_path', $view->vars);
@@ -323,7 +330,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
     public function testJqueryPathWithConfiguredValue()
     {
         $this->ckEditorType->setJqueryPath('foo/jquery.js');
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery_path', $view->vars);
@@ -332,7 +339,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testJqueryPathWithExplicitValue()
     {
-        $form = $this->factory->create('ckeditor', null, array('jquery_path' => 'foo/jquery.js'));
+        $form = $this->factory->create($this->formType, null, array('jquery_path' => 'foo/jquery.js'));
         $view = $form->createView();
 
         $this->assertArrayHasKey('jquery_path', $view->vars);
@@ -341,7 +348,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultConfig()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('config', $view->vars);
@@ -368,7 +375,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->with($this->anything())
             ->will($this->returnValue($options['config']));
 
-        $form = $this->factory->create('ckeditor', null, $options);
+        $form = $this->factory->create($this->formType, null, $options);
         $view = $form->createView();
 
         $this->assertArrayHasKey('config', $view->vars);
@@ -393,7 +400,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->with('default')
             ->will($this->returnValue($config));
 
-        $form = $this->factory->create('ckeditor', null, array('config_name' => 'default'));
+        $form = $this->factory->create($this->formType, null, array('config_name' => 'default'));
         $view = $form->createView();
 
         $this->assertArrayHasKey('config', $view->vars);
@@ -423,7 +430,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->with('config')
             ->will($this->returnValue($options));
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('config', $view->vars);
@@ -451,7 +458,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array_merge($configuredConfig, $explicitConfig)));
 
         $form = $this->factory->create(
-            'ckeditor',
+            $this->formType,
             null,
             array('config_name' => 'default', 'config' => $explicitConfig)
         );
@@ -464,7 +471,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultPlugins()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('plugins', $view->vars);
@@ -490,7 +497,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getPlugins')
             ->will($this->returnValue($plugins));
 
-        $form = $this->factory->create('ckeditor', null, array('plugins' => $plugins));
+        $form = $this->factory->create($this->formType, null, array('plugins' => $plugins));
 
         $view = $form->createView();
 
@@ -512,7 +519,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getPlugins')
             ->will($this->returnValue($plugins));
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertArrayHasKey('plugins', $view->vars);
@@ -545,7 +552,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getPlugins')
             ->will($this->returnValue(array_merge($explicitPlugins, $configuredPlugins)));
 
-        $form = $this->factory->create('ckeditor', null, array('plugins' => $explicitPlugins));
+        $form = $this->factory->create($this->formType, null, array('plugins' => $explicitPlugins));
         $view = $form->createView();
 
         $this->assertArrayHasKey('plugins', $view->vars);
@@ -554,7 +561,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultStylesSet()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertEmpty($view->vars['styles']);
@@ -579,7 +586,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getStylesSets')
             ->will($this->returnValue($stylesSets));
 
-        $form = $this->factory->create('ckeditor', null, array('styles' => $stylesSets));
+        $form = $this->factory->create($this->formType, null, array('styles' => $stylesSets));
 
         $view = $form->createView();
 
@@ -600,7 +607,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getStylesSets')
             ->will($this->returnValue($stylesSets));
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertSame($stylesSets, $view->vars['styles']);
@@ -630,7 +637,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getStylesSets')
             ->will($this->returnValue(array_merge($explicitStylesSets, $configuredStylesSets)));
 
-        $form = $this->factory->create('ckeditor', null, array('styles' => $explicitStylesSets));
+        $form = $this->factory->create($this->formType, null, array('styles' => $explicitStylesSets));
         $view = $form->createView();
 
         $this->assertSame(array_merge($explicitStylesSets, $configuredStylesSets), $view->vars['styles']);
@@ -638,7 +645,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultTemplates()
     {
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertEmpty($view->vars['templates']);
@@ -668,7 +675,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getTemplates')
             ->will($this->returnValue($templates));
 
-        $form = $this->factory->create('ckeditor', null, array('templates' => $templates));
+        $form = $this->factory->create($this->formType, null, array('templates' => $templates));
 
         $view = $form->createView();
 
@@ -694,7 +701,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getTemplates')
             ->will($this->returnValue($templates));
 
-        $form = $this->factory->create('ckeditor');
+        $form = $this->factory->create($this->formType);
         $view = $form->createView();
 
         $this->assertSame($templates, $view->vars['templates']);
@@ -735,7 +742,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getTemplates')
             ->will($this->returnValue(array_merge($explicitTemplates, $configuredTemplates)));
 
-        $form = $this->factory->create('ckeditor', null, array('templates' => $explicitTemplates));
+        $form = $this->factory->create($this->formType, null, array('templates' => $explicitTemplates));
         $view = $form->createView();
 
         $this->assertSame(array_merge($explicitTemplates, $configuredTemplates), $view->vars['templates']);
@@ -758,7 +765,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $form = $this->factory->create('ckeditor', null, $options);
+        $form = $this->factory->create($this->formType, null, $options);
         $view = $form->createView();
 
         $this->assertArrayHasKey('enable', $view->vars);
@@ -787,7 +794,7 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $form = $this->factory->create('ckeditor', null, $options);
+        $form = $this->factory->create($this->formType, null, $options);
         $view = $form->createView();
 
         $this->assertArrayHasKey('enable', $view->vars);

--- a/Tests/Form/Type/CKEditorTypeTest.php
+++ b/Tests/Form/Type/CKEditorTypeTest.php
@@ -13,7 +13,6 @@ namespace Ivory\CKEditorBundle\Tests\Form\Type;
 
 use Ivory\CKEditorBundle\Form\Type\CKEditorType;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * CKEditor type test.
@@ -65,7 +64,8 @@ class CKEditorTypeTest extends \PHPUnit_Framework_TestCase
             ->getFormFactory();
 
         // The form type requires a FQCN in Symfony 3.0 (feature added in Symfony 2.8)
-        $this->formType = Kernel::VERSION_ID >= 20800 ? 'Ivory\CKEditorBundle\Form\Type\CKEditorType' : 'ckeditor';
+        $preferFQCN = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+        $this->formType = $preferFQCN ? 'Ivory\CKEditorBundle\Form\Type\CKEditorType' : 'ckeditor';
     }
 
     /**

--- a/Tests/IvoryCKEditorBundleTest.php
+++ b/Tests/IvoryCKEditorBundleTest.php
@@ -47,6 +47,12 @@ class IvoryCKEditorBundleTest extends \PHPUnit_Framework_TestCase
             ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\AssetsHelperCompilerPass'))
             ->will($this->returnSelf());
 
+        $containerBuilder
+            ->expects($this->at(2))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf('Ivory\CKEditorBundle\DependencyInjection\Compiler\FormTypeCompilerPass'))
+            ->will($this->returnSelf());
+
         $bundle = new IvoryCKEditorBundle();
         $bundle->build($containerBuilder);
     }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "twig/twig": "~1.12"
     },
     "suggest": {
-        "twig/twig": "Allows to use twig templates"
+        "twig/twig": "Allows to use Twig templates"
     },
     "autoload": {
         "psr-4": { "Ivory\\CKEditorBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "satooshi/php-coveralls": "~0.6",
+        "symfony/phpunit-bridge": "~2.7|~3.0",
         "symfony/yaml": "^2.0.5|~3.0",
         "twig/twig": "~1.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=5.3.3",
         "egeloen/json-builder": "~1.0|~2.0",
-        "symfony/dependency-injection": "~2.2",
-        "symfony/form": "~2.2",
-        "symfony/framework-bundle": "~2.2"
+        "symfony/dependency-injection": "~2.2|~3.0",
+        "symfony/form": "~2.2|~3.0",
+        "symfony/framework-bundle": "~2.2|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "satooshi/php-coveralls": "~0.6",
-        "symfony/yaml": "^2.0.5",
+        "symfony/yaml": "^2.0.5|~3.0",
         "twig/twig": "~1.12"
     },
     "suggest": {


### PR DESCRIPTION
This PR adds support for Symfony 3.0.  In doing so, this also addresses the B/C breaking change regarding the form type for Symfony 3.0 where the FQCN is expected.