### PR TITLE
Symfony 3 compatibility

### DIFF
--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -452,13 +452,21 @@ class CKEditorType extends AbstractType
      */
     public function getParent()
     {
-        return 'textarea';
+        return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
     }
 
     /**
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'ckeditor';
     }


### PR DESCRIPTION
Symfony 3.0 uses getBlockPrefix instead of getName, and fully-qualified
class names instead of string names for form types. Maintained
getName() method for backwards compatibility.