### PR TITLE
[Templating] Make Asset/Templating component optional

### DIFF
--- a/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
+++ b/DependencyInjection/Compiler/AssetsHelperCompilerPass.php
@@ -13,10 +13,10 @@ namespace Ivory\CKEditorBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * Create assets.packages fallback alias for symfony < 2.7
+ * Create assets.packages fallback alias for Symfony < 2.7
  *
  * @author Adam Misiorny <adam.misiorny@gmail.com>
  */
@@ -27,15 +27,8 @@ class AssetsHelperCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('assets.packages')) {
-            return;
+        if (Kernel::VERSION_ID < 27000 && $container->has('templating.helper.assets')) {
+            $container->setAlias('assets.packages', 'templating.helper.assets');
         }
-
-        if (!$container->hasDefinition('templating.helper.assets')) {
-            throw new ServiceNotFoundException('templating.helper.assets');
-        }
-
-        // create fallback alias for symfony < 2.7
-        $container->setAlias('assets.packages', 'templating.helper.assets');
     }
 }

--- a/Templating/CKEditorHelper.php
+++ b/Templating/CKEditorHelper.php
@@ -49,7 +49,7 @@ class CKEditorHelper extends Helper
      */
     public function renderBasePath($basePath)
     {
-        return $this->fixPath($this->getAssetsHelper()->getUrl($basePath));
+        return $this->fixPath($this->fixUrl($basePath));
     }
 
     /**
@@ -61,7 +61,7 @@ class CKEditorHelper extends Helper
      */
     public function renderJsPath($jsPath)
     {
-        return $this->getAssetsHelper()->getUrl($jsPath);
+        return $this->fixUrl($jsPath);
     }
 
     /**
@@ -136,7 +136,7 @@ class CKEditorHelper extends Helper
         return sprintf(
             'CKEDITOR.plugins.addExternal("%s", "%s", "%s");',
             $name,
-            $this->fixPath($this->getAssetsHelper()->getUrl($plugin['path'])),
+            $this->fixPath($this->fixUrl($plugin['path'])),
             $plugin['filename']
         );
     }
@@ -174,9 +174,7 @@ class CKEditorHelper extends Helper
     public function renderTemplate($name, array $template)
     {
         if (isset($template['imagesPath'])) {
-            $template['imagesPath'] = $this->fixPath(
-                $this->getAssetsHelper()->getUrl($template['imagesPath'])
-            );
+            $template['imagesPath'] = $this->fixPath($this->fixUrl($template['imagesPath']));
         }
 
         $this->jsonBuilder
@@ -224,7 +222,7 @@ class CKEditorHelper extends Helper
 
             $config['contentsCss'] = array();
             foreach ($cssContents as $cssContent) {
-                $config['contentsCss'][] = $this->fixPath($this->getAssetsHelper()->getUrl($cssContent));
+                $config['contentsCss'][] = $this->fixPath($this->fixUrl($cssContent));
             }
         }
 
@@ -331,13 +329,31 @@ class CKEditorHelper extends Helper
     }
 
     /**
+     * Fixes an url.
+     *
+     * @param string $url The url.
+     *
+     * @return string The fixed url.
+     */
+    private function fixUrl($url)
+    {
+        $assetsHelper = $this->getAssetsHelper();
+
+        if ($assetsHelper !== null) {
+            $url = $assetsHelper->getUrl($url);
+        }
+
+        return $url;
+    }
+
+    /**
      * Gets the assets helper.
      *
-     * @return \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper The assets helper.
+     * @return \Symfony\Component\Asset\Packages|\Symfony\Component\Templating\Helper\CoreAssetsHelper|null The assets helper.
      */
     private function getAssetsHelper()
     {
-        return $this->container->get('assets.packages');
+        return $this->container->get('assets.packages', ContainerInterface::NULL_ON_INVALID_REFERENCE);
     }
 
     /**

--- a/Tests/Templating/CKEditorHelperTest.php
+++ b/Tests/Templating/CKEditorHelperTest.php
@@ -59,7 +59,7 @@ class CKEditorHelperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValueMap(array(
                 array(
                     'assets.packages',
-                    ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
+                    ContainerInterface::NULL_ON_INVALID_REFERENCE,
                     $this->assetsHelperMock,
                 ),
                 array(


### PR DESCRIPTION
This PR fixes #200 by first, fixing the BC templating helper assets compiler pass in order to make the `templating.helper.assets` optional and second, by making the `CKEditorHelper` ables to deal with optional `asset.packages`.