### PR TITLE
Misc. doc tweaks

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,14 +11,15 @@ Overview
 --------
 
 The bundle integrates `CKEditor`_ into `Symfony`_ via the `Form Component`_. It
-automatically registers a new type called ``ckeditor`` which can be easily as
-well as highly configured. This type extends the `textarea`_ one, meaning all
-textarea options are available.
+automatically registers a new type called ``ckeditor`` which can be fully
+configured. This type extends the `textarea`_ one, meaning all textarea options
+are available.
 
 Here, an example where we customize the `CKEditor config`_:
 
 .. code-block:: php
 
+    // Symfony 2.8 and previous versions
     $builder->add('field', 'ckeditor', array(
         'config' => array(
             'uiColor' => '#ffffff',
@@ -26,14 +27,15 @@ Here, an example where we customize the `CKEditor config`_:
         ),
     ));
 
-.. note::
+    // Symfony 3.0 and newer versions
+    use Ivory\CKEditorBundle\Form\Type\CKEditorType;
 
-    As of Symfony 2.8, the second argument of ``$builder->add()`` accepts the
-    fully qualified class name of the form type and it becomes mandatory to use
-    it in Symfony 3.0. Depending on your Symfony versions, you should replace
-    the ``ckeditor`` parameter by
-    ``Ivory\CKEditorBundle\Form\Type\CKEditorType`` or by
-    ``CKEditorType::class`` if your project relies on PHP 5.5+.
+    $builder->add('field', CKEditorType::class, array(
+        'config' => array(
+            'uiColor' => '#ffffff',
+            //...
+        ),
+    ));
 
 Installation
 ------------

--- a/Resources/doc/usage/config.rst
+++ b/Resources/doc/usage/config.rst
@@ -2,7 +2,7 @@ Define reusable configuration
 =============================
 
 The CKEditor bundle provides an advanced configuration which can be reused on
-multiple CKEditor instance. Instead of duplicate the configuration on each form
+multiple CKEditor instances. Instead of duplicate the configuration on each form
 builder, you can directly configure it once and reuse it all the time. The
 bundle allows you to define as many configurations as you want.
 
@@ -52,9 +52,9 @@ If you want to override some parts of the defined config, you can still use the
 Define default configuration
 ----------------------------
 
-If you want to define globally your configuration in order to make it used by
-default without having to use the ``config_name`` option, you can use the
-``default_config`` node:
+If you want to define your configuration globally to use it by default without
+having to use the ``config_name`` option, you can use the ``default_config``
+node:
 
 .. code-block:: yaml
 

--- a/Resources/doc/usage/file-browse-upload.rst
+++ b/Resources/doc/usage/file-browse-upload.rst
@@ -85,20 +85,20 @@ but much more powerful closure and so make it aware of your dependencies:
         ),
     ));
 
-Integration
------------
+Integration with Other Projects
+-------------------------------
 
 If you want to simplify your life, you can directly use other bundles which have
 already integrated the concept explain in the previous chapter.
 
-CoopTilleulsCKEditorSonataMediaBundle
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sonata integration
+~~~~~~~~~~~~~~~~~~
 
 The `CoopTilleulsCKEditorSonataMediaBundle`_ provides a `SonataMedia`_
 integration with this bundle.
 
-FMElfinderBundle
-~~~~~~~~~~~~~~~~
+ELFinder integration
+~~~~~~~~~~~~~~~~~~~~
 
 The `FMElfinderBundle`_ provides a `ELFinder`_ integration with this bundle.
 

--- a/Resources/doc/usage/inline.rst
+++ b/Resources/doc/usage/inline.rst
@@ -3,7 +3,7 @@ Use inline editing
 
 By default, the bundle uses a `Classic Editing`_ which relies on
 ``CKEDITOR.replace``. If you want to use the `Inline Editing`_ which relies on
-``CKEDITOR.inline``, you can configure globally it in your configuration:
+``CKEDITOR.inline``, you can configure it globally in your configuration:
 
 .. code-block:: yaml
 

--- a/Resources/doc/usage/loading.rst
+++ b/Resources/doc/usage/loading.rst
@@ -1,11 +1,11 @@
-Load manually CKEditor
+Load CKEditor manually
 ======================
 
-By default, all fields loads the CKEditor library. It means if you have multiple
-CKEditor fields, there will be multiple CKEditor library loading (as much as you
-have fields). If you want to control it, you can configure the bundle to not
-load the library at all and let you the control of it. To disable the CKEditor
-library loading, you can do it globally in your configuration:
+By default, all fields load the CKEditor library. It means that if you have
+multiple CKEditor fields, there will be multiple CKEditor library loadings (as
+many as your fields). If you want to control it, you can configure the bundle to
+not load the library at all and let you the control of it. To disable the
+CKEditor library loading, you can do it globally in your configuration:
 
 .. code-block:: yaml
 
@@ -22,4 +22,4 @@ Or you can disable it in your widget:
 .. note::
 
     CKEditor must be loaded before any fields have been rendered, so we
-    recommend you to register it in the ``head`` of your page.
+    recommend you to register it in the ``<head>`` of your page.

--- a/Resources/doc/usage/textarea-sync.rst
+++ b/Resources/doc/usage/textarea-sync.rst
@@ -3,8 +3,8 @@ Synchronize the textarea
 
 When the textarea is transformed into a CKEditor widget, the textarea value is
 no more populated except when the form is submitted. Then, it leads to issues
-when you try to serialize form or you try to rely on the textarea value in
-javascript. To automatically synchronize the textarea value, you can do it
+when you try to serialize the form or you try to rely on the textarea value in
+JavaScript. To automatically synchronize the textarea value, you can do it
 globally in your configuration:
 
 .. code-block:: yaml


### PR DESCRIPTION
Some of these changes could be considered "errors", like the long section titles which break the Table of Contents:

![toc_broken](https://cloud.githubusercontent.com/assets/73419/13289824/ac6fe318-db11-11e5-83ec-bff9e09f5d0b.png)

But others are debatable ... so feel free to ignore the changes you don't agree with. Thanks!


