### PR TITLE
Fixes Deprecated method usage

### DIFF
--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -13,6 +13,7 @@ namespace Ivory\CKEditorBundle\Renderer;
 
 use Ivory\JsonBuilder\JsonBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -212,7 +213,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
                 $config[$url] = $this->getRouter()->generate(
                     $config[$route],
                     isset($config[$routeParameters]) ? $config[$routeParameters] : array(),
-                    isset($config[$routeAbsolute]) ? $config[$routeAbsolute] : false
+                    isset($config[$routeAbsolute]) ? $config[$routeAbsolute] : UrlGeneratorInterface::ABSOLUTE_PATH
                 );
             }
 


### PR DESCRIPTION
In Symfony 2.8.4 i get the following deprecation error message on the 4.0.1 tag
in dev-master it has changed a bit but the error still occurs

The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead.