### PR TITLE
[Routing] Fix reference type deprecation

### DIFF
--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -13,6 +13,7 @@ namespace Ivory\CKEditorBundle\Renderer;
 
 use Ivory\JsonBuilder\JsonBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -212,7 +213,13 @@ class CKEditorRenderer implements CKEditorRendererInterface
                 $config[$url] = $this->getRouter()->generate(
                     $config[$route],
                     isset($config[$routeParameters]) ? $config[$routeParameters] : array(),
-                    isset($config[$routeAbsolute]) ? $config[$routeAbsolute] : false
+                    isset($config[$routeAbsolute])
+                        ? $config[$routeAbsolute]
+                        : (
+                            defined('Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_PATH')
+                                ? UrlGeneratorInterface::ABSOLUTE_PATH
+                                : false
+                        )
                 );
             }
 


### PR DESCRIPTION
This PR fixes #229 by removing the routing deprecation while keeping it compatible with previous Symfony versions.