### PR TITLE
RequireJS wrapper - like the jQuery wrapper

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('inline')->end()
                 ->booleanNode('autoload')->end()
                 ->booleanNode('jquery')->end()
+                ->booleanNode('requirejs')->end()
                 ->booleanNode('input_sync')->end()
                 ->scalarNode('base_path')->end()
                 ->scalarNode('js_path')->end()

--- a/DependencyInjection/IvoryCKEditorExtension.php
+++ b/DependencyInjection/IvoryCKEditorExtension.php
@@ -85,6 +85,10 @@ class IvoryCKEditorExtension extends ConfigurableExtension
             $formType->addMethodCall('useJquery', array($config['jquery']));
         }
 
+        if (isset($config['requirejs'])) {
+            $formType->addMethodCall('useRequireJS', array($config['requirejs']));
+        }
+
         if (isset($config['input_sync'])) {
             $formType->addMethodCall('isInputSync', array($config['input_sync']));
         }

--- a/Form/Type/CKEditorType.php
+++ b/Form/Type/CKEditorType.php
@@ -49,6 +49,8 @@ class CKEditorType extends AbstractType
     /** @var boolean */
     private $jquery = false;
 
+    private $requirejs = false;
+
     /** @var boolean */
     private $inputSync = false;
 
@@ -187,6 +189,22 @@ class CKEditorType extends AbstractType
         }
 
         return $this->jquery;
+    }
+
+    /**
+     * Checks/Sets if the requirejs adapter is loaded.
+     *
+     * @param boolean $requirejs TRUE if the requirejs adapter is loaded else FALSE.
+     *
+     * @return boolean TRUE if the requirejs adapter is loaded else FALSE.
+     */
+    public function useRequireJS($requirejs = null)
+    {
+        if ($requirejs !== null) {
+            $this->requirejs = (bool) $requirejs;
+        }
+
+        return $this->requirejs;
     }
 
     /**
@@ -358,6 +376,7 @@ class CKEditorType extends AbstractType
             $builder->setAttribute('auto_inline', $options['auto_inline']);
             $builder->setAttribute('inline', $options['inline']);
             $builder->setAttribute('jquery', $options['jquery']);
+            $builder->setAttribute('requirejs', $options['requirejs']);
             $builder->setAttribute('input_sync', $options['input_sync']);
             $builder->setAttribute('base_path', $options['base_path']);
             $builder->setAttribute('js_path', $options['js_path']);
@@ -400,6 +419,7 @@ class CKEditorType extends AbstractType
             $view->vars['auto_inline'] = $form->getConfig()->getAttribute('auto_inline');
             $view->vars['inline'] = $form->getConfig()->getAttribute('inline');
             $view->vars['jquery'] = $form->getConfig()->getAttribute('jquery');
+            $view->vars['requirejs'] = $form->getConfig()->getAttribute('requirejs');
             $view->vars['input_sync'] = $form->getConfig()->getAttribute('input_sync');
             $view->vars['base_path'] = $form->getConfig()->getAttribute('base_path');
             $view->vars['js_path'] = $form->getConfig()->getAttribute('js_path');
@@ -424,6 +444,7 @@ class CKEditorType extends AbstractType
                 'auto_inline' => $this->autoInline,
                 'inline'      => $this->inline,
                 'jquery'      => $this->jquery,
+                'requirejs'   => $this->requirejs,
                 'input_sync'  => $this->inputSync,
                 'base_path'   => $this->basePath,
                 'js_path'     => $this->jsPath,
@@ -442,6 +463,7 @@ class CKEditorType extends AbstractType
             'auto_inline' => 'bool',
             'inline'      => 'bool',
             'jquery'      => 'bool',
+            'requirejs'   => 'bool',
             'input_sync'  => 'bool',
             'config_name' => array('string', 'null'),
             'base_path'   => 'string',

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -33,6 +33,10 @@
             $(function () {
         {% endif %}
 
+        {% if requirejs %}
+            require(['ckeditor'], function() {
+        {% endif %}
+
         {{ ckeditor_destroy(id) }}
 
         {% for plugin_name, plugin in plugins %}
@@ -54,6 +58,10 @@
             inline: inline,
             input_sync: input_sync
         }) }}
+
+        {% if requirejs %}
+            });
+        {% endif %}
 
         {% if jquery %}
             });

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": ">=5.3.3",
         "egeloen/json-builder": "~1.0|~2.0",
-        "egeloen/form-extra-bundle": "~1.0.0",
         "symfony/dependency-injection": "~2.2|~3.0",
         "symfony/form": "~2.2|~3.0",
         "symfony/framework-bundle": "~2.2|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": ">=5.3.3",
         "egeloen/json-builder": "~1.0|~2.0",
+        "egeloen/form-extra-bundle": "~1.0.0",
         "symfony/dependency-injection": "~2.2|~3.0",
         "symfony/form": "~2.2|~3.0",
         "symfony/framework-bundle": "~2.2|~3.0"


### PR DESCRIPTION
I've made a change to wrap code in 'require' in a manner similar to how the 'jquery' option works.

There's a little manual setup to do when using requirejs:

```
{
    paths: {
        // ...
        'ckeditor': '{{ asset("bundles/ivoryckeditor/ckeditor") }}'
    },
    shim: {
        // ...
        'ckeditor': {
            deps: ['jQuery'],
            exports: 'CKEDITOR'
        }
    }
}
```