### PR TITLE
Removes dead code which break twig template compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
         - SYMFONY_VERSION=2.3.*
 
 install:
-    - composer self-update
     - if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then composer config secure-http false; fi
     - if [[ "$TRAVIS_PHP_VERSION" == "5.3.3" ]]; then composer config disable-tls true; fi
+    - composer self-update
     - composer require --no-update symfony/framework-bundle:${SYMFONY_VERSION}
     - composer require --no-update symfony/form:${SYMFONY_VERSION}
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi

--- a/DependencyInjection/Compiler/ResourceCompilerPass.php
+++ b/DependencyInjection/Compiler/ResourceCompilerPass.php
@@ -40,10 +40,7 @@ class ResourceCompilerPass implements CompilerPassInterface
             $container->setParameter(
                 $parameter,
                 array_merge(
-                    array(
-                        'IvoryCKEditorBundle:Form:javascript.html.twig',
-                        'IvoryCKEditorBundle:Form:ckeditor_widget.html.twig',
-                    ),
+                    array('IvoryCKEditorBundle:Form:ckeditor_widget.html.twig'),
                     $container->getParameter($parameter)
                 )
             );

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -12,12 +12,6 @@
     {% endif %}
 {% endblock %}
 
-{% block ckeditor_javascript_prototype %}
-    {% if enable and async %}
-        {{ block('_ckeditor_javascript') }}
-    {% endif %}
-{% endblock %}
-
 {% block _ckeditor_javascript %}
     {% if autoload %}
         <script type="text/javascript">

--- a/Resources/views/Form/form_javascript.html.php
+++ b/Resources/views/Form/form_javascript.html.php
@@ -1,3 +1,0 @@
-<?php foreach ($form as $child) : ?>
-    <?php echo $view['ivory_ckeditor_javascript']->renderJavascript($child); ?>
-<?php endforeach; ?>

--- a/Resources/views/Form/javascript.html.twig
+++ b/Resources/views/Form/javascript.html.twig
@@ -1,7 +1,0 @@
-{% block form_javascript %}
-    {% for child in form %}
-        {{ form_javascript(child) }}
-    {% endfor %}
-{% endblock %}
-
-{% block button_javascript %}{% endblock %}

--- a/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourceCompilerPassTest.php
@@ -62,7 +62,6 @@ class ResourceCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->identicalTo($parameter),
                 $this->identicalTo(array(
-                    'IvoryCKEditorBundle:Form:javascript.html.twig',
                     'IvoryCKEditorBundle:Form:ckeditor_widget.html.twig',
                     $template,
                 ))


### PR DESCRIPTION
This PR fixes #235 by removing dead code I have moved to the [IvoryFormExtraBundle](https://github.com/egeloen/IvoryFormExtraBundle) which have broken the twig template compilation.