### PR TITLE
Update documentation for plugin configuration.

### DIFF
--- a/Resources/doc/usage/plugin.rst
+++ b/Resources/doc/usage/plugin.rst
@@ -25,8 +25,9 @@ globally in your configuration:
     # app/config/config.yml
     ivory_ck_editor:
         default_config: my_config
-        config:
-            extraPlugins: "wordcount"
+        configs:
+            my_config:
+                extraPlugins: "wordcount"
         plugins:
             wordcount:
                 path:     "/bundles/mybundle/wordcount/"


### PR DESCRIPTION
When configuring a plugin in config.yml, the configs must be under a "configs" root node.