### PR TITLE
CKEditorTemplate using Twig render view

### DIFF
--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -140,23 +140,23 @@ class CKEditorRenderer implements CKEditorRendererInterface
         }
         
         /**
-          Using Templating service to render a twig view;
-          Before in config.yml (or CkeditorType::class) set the parameter 'html' : '@MyBundle:Templates:myTemplate-1.html.twig'
-          Exemple :
-            ivory_ck_editor:
-                 configs:
-                    my_config:
-                    extraPlugins : "templates,htmlwriter"
-                 templates:    "my_templates"
-            templates:
-                my_templates:
-                     imagesPath: "/bundles/mybundle/templates/images"
-                     templates:
-                         -
-                            title:       "My Template"
-                            image:       "image.jpg"
-                            description: "My awesome template"
-                            html:        '@MyBundle:Templates:myTemplate-1.html.twig'
+         * Using Templating service to render a twig view;
+         * Before in config.yml (or CkeditorType::class) set the parameter 'html' : '@MyBundle:Templates:myTemplate-1.html.twig'
+         * Exemple :
+         *   ivory_ck_editor:
+         *        configs:
+         *           my_config:
+         *           extraPlugins : "templates,htmlwriter"
+         *        templates:    "my_templates"
+         *   templates:
+         *       my_templates:
+         *            imagesPath: "/bundles/mybundle/templates/images"
+         *            templates:
+         *                -
+         *                   title:       "My Template"
+         *                   image:       "image.jpg"
+         *                   description: "My awesome template"
+         *                   html:        '@MyBundle:Templates:myTemplate-1.html.twig'
          */
         foreach ($template['templates'] as $key => $view) {
             if (substr($view['html'], 0, 1) === '@') {

--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -138,6 +138,31 @@ class CKEditorRenderer implements CKEditorRendererInterface
         if (isset($template['imagesPath'])) {
             $template['imagesPath'] = $this->fixPath($this->fixUrl($template['imagesPath']));
         }
+        
+        /**
+          Using Templating service to render a twig view;
+          Before in config.yml (or CkeditorType::class) set the parameter 'html' : '@MyBundle:Templates:myTemplate-1.html.twig'
+          Exemple :
+            ivory_ck_editor:
+                 configs:
+                    my_config:
+                    extraPlugins : "templates,htmlwriter"
+                 templates:    "my_templates"
+            templates:
+                my_templates:
+                     imagesPath: "/bundles/mybundle/templates/images"
+                     templates:
+                         -
+                            title:       "My Template"
+                            image:       "image.jpg"
+                            description: "My awesome template"
+                            html:        '@MyBundle:Templates:myTemplate-1.html.twig'
+         */
+        foreach ($template['templates'] as $key => $view) {
+            if (substr($view['html'], 0, 1) === '@') {
+                $template['templates'][$key]['html'] = $this->container->get('templating')->render(trim($view['html'], '@'));
+            } 
+        }
 
         $this->jsonBuilder
             ->reset()


### PR DESCRIPTION
Hi!
(sorry for my bad english it's not my language and i'm not "Super Programmer" ;) )

I dislike CKEditorTemplate using HTML ('<\p>My template<\/p>') in YML (templates - title, html... ) ... i have an idea. Pass a twig view name ('@AppBundle:myTemplate.html.twig') instead raw html;

I have modified in my fork this file : Render/CKEditorRender.php ( renderTemplate() ), and added juste one loop to handle each templates 'html' value and use :
` $this->container->get('templating')->render($view);`

This small code work well, for me. But, your are better programmer that me, you can maybe upgrade this.

I hope my explanations are clear ! :+1: 

Good Bye !