### PR TITLE
Automatically use the first config as default config

### DIFF
--- a/DependencyInjection/IvoryCKEditorExtension.php
+++ b/DependencyInjection/IvoryCKEditorExtension.php
@@ -125,6 +125,10 @@ class IvoryCKEditorExtension extends ConfigurableExtension
 
         $definition = $container->getDefinition('ivory_ck_editor.config_manager');
         foreach ($config['configs'] as $name => $configuration) {
+            if (!isset($config['default_config'])) {
+                $config['default_config'] = $name;
+            }
+
             $definition->addMethodCall('setConfig', array($name, $configuration));
         }
 

--- a/Resources/doc/usage/config.rst
+++ b/Resources/doc/usage/config.rst
@@ -25,6 +25,11 @@ Define a configuration
                 extraPlugins:           "wordcount"
                 # ...
 
+.. note::
+
+    The first configuration defined will be used as default configuration
+    if you don't explicitly configure it.
+
 Use a configuration
 -------------------
 

--- a/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractIvoryCKEditorExtensionTest.php
@@ -259,6 +259,22 @@ abstract class AbstractIvoryCKEditorExtensionTest extends AbstractTestCase
         $this->assertSame($expected, $configManager->getConfigs());
     }
 
+    public function testDefaultConfiguration()
+    {
+        $this->loadConfiguration($this->container, 'default_configuration');
+        $this->container->compile();
+
+        $configManager = $this->container->get('ivory_ck_editor.config_manager');
+
+        $expected = array(
+            'default' => array('uiColor' => '#000000'),
+            'custom'  => array('uiColor' => '#ffffff'),
+        );
+
+        $this->assertSame('default', $configManager->getDefaultConfig());
+        $this->assertSame($expected, $configManager->getConfigs());
+    }
+
     public function testBasicToolbar()
     {
         $this->loadConfiguration($this->container, 'basic_toolbar');

--- a/Tests/Fixtures/config/Yaml/default_configuration.yml
+++ b/Tests/Fixtures/config/Yaml/default_configuration.yml
@@ -1,0 +1,6 @@
+ivory_ck_editor:
+    configs:
+        default:
+            uiColor: "#000000"
+        custom:
+            uiColor: "#ffffff"

--- a/Tests/Template/TwigTemplateTest.php
+++ b/Tests/Template/TwigTemplateTest.php
@@ -33,10 +33,15 @@ class TwigTemplateTest extends AbstractTemplateTest
     {
         parent::setUp();
 
-        $this->twig = new \Twig_Environment(new \Twig_Loader_Filesystem(array(__DIR__.'/../../Resources/views/Form')));
-        $this->twig->addExtension(new CKEditorExtension($this->renderer));
+        $symfonyTheme = '{% block widget_attributes %}{% endblock %}';
+        $ckeditorTheme = file_get_contents(__DIR__.'/../../Resources/views/Form/ckeditor_widget.html.twig');
 
-        $this->template = $this->twig->loadTemplate('ckeditor_widget.html.twig');
+        $this->twig = new \Twig_Environment(new \Twig_Loader_Array(array(
+            'ckeditor' => $symfonyTheme.$ckeditorTheme,
+        )));
+
+        $this->twig->addExtension(new CKEditorExtension($this->renderer));
+        $this->template = $this->twig->loadTemplate('ckeditor');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,18 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0",
+        "symfony/asset": "^2.2|^3.0",
         "symfony/phpunit-bridge": "^2.7|^3.0",
+        "symfony/templating": "^2.2|^3.0",
+        "symfony/twig-bridge": "^2.2|^3.0",
         "symfony/yaml": "^2.0.5|^3.0",
         "twig/twig": "^1.12"
     },
     "suggest": {
         "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously",
+        "symfony/asset": "Allows to rewrite/version assets",
+        "symfony/templating": "Allows to use PHP templates",
+        "symfony/twig-bridge": "Allows to use Twig templates",
         "twig/twig": "Allows to use Twig templates"
     },
     "autoload": {


### PR DESCRIPTION
This PR automatically configures the first configuration node as the default one, it updates the `composer.json` file in order to align with the last changes done in `symfony/framework-bundle` and it also fixes tests according to the last deprecations triggered...