### PR TITLE
Only strip assets version when the path is a directory

### DIFF
--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -42,7 +42,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
      */
     public function renderBasePath($basePath)
     {
-        return $this->fixPath($this->fixUrl($basePath));
+        return $this->fixPath($basePath);
     }
 
     /**
@@ -50,7 +50,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
      */
     public function renderJsPath($jsPath)
     {
-        return $this->fixUrl($jsPath);
+        return $this->fixPath($jsPath);
     }
 
     /**
@@ -111,7 +111,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
         return sprintf(
             'CKEDITOR.plugins.addExternal("%s", "%s", "%s");',
             $name,
-            $this->fixPath($this->fixUrl($plugin['path'])),
+            $this->fixPath($plugin['path']),
             $plugin['filename']
         );
     }
@@ -136,7 +136,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
     public function renderTemplate($name, array $template)
     {
         if (isset($template['imagesPath'])) {
-            $template['imagesPath'] = $this->fixPath($this->fixUrl($template['imagesPath']));
+            $template['imagesPath'] = $this->fixPath($template['imagesPath']);
         }
 
         if (isset($template['templates'])) {
@@ -190,7 +190,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
 
             $config['contentsCss'] = [];
             foreach ($cssContents as $cssContent) {
-                $config['contentsCss'][] = $this->fixUrl($cssContent);
+                $config['contentsCss'][] = $this->fixPath($cssContent);
             }
         }
 
@@ -283,21 +283,19 @@ class CKEditorRenderer implements CKEditorRendererInterface
      */
     private function fixPath($path)
     {
-        if (($position = strpos($path, '?')) !== false) {
-            return substr($path, 0, $position);
+        $helper = $this->getAssets();
+
+        if ($helper === null) {
+            return $path;
         }
 
-        return $path;
-    }
+        $url = $helper->getUrl($path);
 
-    /**
-     * @param string $url
-     *
-     * @return string
-     */
-    private function fixUrl($url)
-    {
-        return ($assetsHelper = $this->getAssets()) !== null ? $assetsHelper->getUrl($url) : $url;
+        if (substr($path, -1) === '/' && ($position = strpos($url, '?')) !== false) {
+            $url = substr($url, 0, $position);
+        }
+
+        return $url;
     }
 
     /**

--- a/Renderer/CKEditorRenderer.php
+++ b/Renderer/CKEditorRenderer.php
@@ -190,7 +190,7 @@ class CKEditorRenderer implements CKEditorRendererInterface
 
             $config['contentsCss'] = [];
             foreach ($cssContents as $cssContent) {
-                $config['contentsCss'][] = $this->fixPath($this->fixUrl($cssContent));
+                $config['contentsCss'][] = $this->fixUrl($cssContent);
             }
         }
 

--- a/Tests/Renderer/CKEditorRendererTest.php
+++ b/Tests/Renderer/CKEditorRendererTest.php
@@ -242,7 +242,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider pathContentsCssProvider
      */
     public function testRenderWidgetWithStringContentsCss($path, $asset, $url)
     {
@@ -263,7 +263,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string[] $assets
      * @param string[] $urls
      *
-     * @dataProvider pathsProvider
+     * @dataProvider pathsContentsCssProvider
      */
     public function testRenderWidgetWithArrayContentsCss(array $paths, array $assets, array $urls)
     {
@@ -657,6 +657,32 @@ class CKEditorRendererTest extends AbstractTestCase
             [['path1', 'path2'], ['url1?v=2', 'url2'], ['url1', 'url2']],
             [['path1', 'path2'], ['url1', 'url2?v=2'], ['url1', 'url2']],
             [['path1', 'path2'], ['url1?v=2', 'url2?v=2'], ['url1', 'url2']],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function pathContentsCssProvider()
+    {
+        return [
+            ['path', 'url', 'url'],
+            ['path', 'url?v=2', 'url?v=2'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function pathsContentsCssProvider()
+    {
+        return [
+            [['path'], ['url'], ['url']],
+            [['path'], ['url?v=2'], ['url?v=2']],
+            [['path1', 'path2'], ['url1', 'url2'], ['url1', 'url2']],
+            [['path1', 'path2'], ['url1?v=2', 'url2'], ['url1?v=2', 'url2']],
+            [['path1', 'path2'], ['url1', 'url2?v=2'], ['url1', 'url2?v=2']],
+            [['path1', 'path2'], ['url1?v=2', 'url2?v=2'], ['url1?v=2', 'url2?v=2']],
         ];
     }
 

--- a/Tests/Renderer/CKEditorRendererTest.php
+++ b/Tests/Renderer/CKEditorRendererTest.php
@@ -135,7 +135,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider directoryAssetProvider
      */
     public function testRenderBasePath($path, $asset, $url)
     {
@@ -242,7 +242,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathContentsCssProvider
+     * @dataProvider fileAssetProvider
      */
     public function testRenderWidgetWithStringContentsCss($path, $asset, $url)
     {
@@ -253,7 +253,7 @@ class CKEditorRendererTest extends AbstractTestCase
             ->will($this->returnValue($asset));
 
         $this->assertSame(
-            'CKEDITOR.replace("foo", {"contentsCss":['.json_encode($url).']});',
+            'CKEDITOR.replace("foo", {"contentsCss":["'.$url.'"]});',
             $this->renderer->renderWidget('foo', ['contentsCss' => $path])
         );
     }
@@ -263,7 +263,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string[] $assets
      * @param string[] $urls
      *
-     * @dataProvider pathsContentsCssProvider
+     * @dataProvider filesAssetProvider
      */
     public function testRenderWidgetWithArrayContentsCss(array $paths, array $assets, array $urls)
     {
@@ -470,7 +470,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider directoryAssetProvider
      */
     public function testRenderPlugin($path, $asset, $url)
     {
@@ -481,7 +481,7 @@ class CKEditorRendererTest extends AbstractTestCase
             ->will($this->returnValue($asset));
 
         $this->assertSame(
-            'CKEDITOR.plugins.addExternal("foo", '.json_encode($url).', "bat");',
+            'CKEDITOR.plugins.addExternal("foo", "'.$url.'", "bat");',
             $this->renderer->renderPlugin('foo', ['path' => $path, 'filename' => 'bat'])
         );
     }
@@ -499,7 +499,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider directoryAssetProvider
      */
     public function testRenderTemplate($path, $asset, $url)
     {
@@ -529,7 +529,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider directoryAssetProvider
      */
     public function testRenderTemplateWithTwigTemplating($path, $asset, $url)
     {
@@ -579,7 +579,7 @@ class CKEditorRendererTest extends AbstractTestCase
      * @param string $asset
      * @param string $url
      *
-     * @dataProvider pathProvider
+     * @dataProvider directoryAssetProvider
      */
     public function testRenderTemplateWithPhpTemplating($path, $asset, $url)
     {
@@ -637,52 +637,37 @@ class CKEditorRendererTest extends AbstractTestCase
     /**
      * @return array
      */
-    public function pathProvider()
+    public function directoryAssetProvider()
     {
         return [
-            ['path', 'url', 'url'],
-            ['path', 'url?v=2', 'url'],
+            ['directory/', 'url/', 'url/'],
+            ['directory/', 'url/?v=2', 'url/'],
         ];
     }
 
     /**
      * @return array
      */
-    public function pathsProvider()
+    public function fileAssetProvider()
     {
         return [
-            [['path'], ['url'], ['url']],
-            [['path'], ['url?v=2'], ['url']],
-            [['path1', 'path2'], ['url1', 'url2'], ['url1', 'url2']],
-            [['path1', 'path2'], ['url1?v=2', 'url2'], ['url1', 'url2']],
-            [['path1', 'path2'], ['url1', 'url2?v=2'], ['url1', 'url2']],
-            [['path1', 'path2'], ['url1?v=2', 'url2?v=2'], ['url1', 'url2']],
+            ['file.js', 'url.js', 'url.js'],
+            ['file.js', 'url.js?v=2', 'url.js?v=2'],
         ];
     }
 
     /**
      * @return array
      */
-    public function pathContentsCssProvider()
+    public function filesAssetProvider()
     {
         return [
-            ['path', 'url', 'url'],
-            ['path', 'url?v=2', 'url?v=2'],
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    public function pathsContentsCssProvider()
-    {
-        return [
-            [['path'], ['url'], ['url']],
-            [['path'], ['url?v=2'], ['url?v=2']],
-            [['path1', 'path2'], ['url1', 'url2'], ['url1', 'url2']],
-            [['path1', 'path2'], ['url1?v=2', 'url2'], ['url1?v=2', 'url2']],
-            [['path1', 'path2'], ['url1', 'url2?v=2'], ['url1', 'url2?v=2']],
-            [['path1', 'path2'], ['url1?v=2', 'url2?v=2'], ['url1?v=2', 'url2?v=2']],
+            [['file'], ['url'], ['url']],
+            [['file'], ['url?v=2'], ['url?v=2']],
+            [['file1', 'file2'], ['url1', 'url2'], ['url1', 'url2']],
+            [['file1', 'file2'], ['url1?v=2', 'url2'], ['url1?v=2', 'url2']],
+            [['file1', 'file2'], ['url1', 'url2?v=2'], ['url1', 'url2?v=2']],
+            [['file1', 'file2'], ['url1?v=2', 'url2?v=2'], ['url1?v=2', 'url2?v=2']],
         ];
     }
 


### PR DESCRIPTION
This PR fixes #283 and is the follow up of #284. It makes sure that we only strip asset version when the path is a directory (the last char is '/').