### PR TITLE
[Composer] Add a script handler installing CKEditor source

### DIFF
--- a/Command/CKEditorInstallerCommand.php
+++ b/Command/CKEditorInstallerCommand.php
@@ -57,7 +57,7 @@ class CKEditorInstallerCommand extends Command
                 'clear',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'How to clear previous CKEditor installation (drop, keep or abort)'
+                'How to clear previous CKEditor installation (drop, keep or skip)'
             )
             ->addOption(
                 'exclude',
@@ -87,7 +87,7 @@ you can control how it should be handled in non-interactive mode:
 
   <info>php %command.full_name% --clear=drop</info>
   <info>php %command.full_name% --clear=keep</info>
-  <info>php %command.full_name% --clear=abort</info>
+  <info>php %command.full_name% --clear=skip</info>
   
 You can exclude path(s) when extracting CKEditor:
 
@@ -107,6 +107,8 @@ EOF
 
         if ($success) {
             $this->success('CKEditor has been successfully installed...', $output);
+        } else {
+            $this->info('CKEditor installation has been skipped...', $output);
         }
     }
 
@@ -165,9 +167,9 @@ EOF
                             'What do you want to do?',
                         ],
                         $choices = [
-                            CKEditorInstaller::CLEAR_DROP  => 'Drop the directory & reinstall CKEditor',
-                            CKEditorInstaller::CLEAR_KEEP  => 'Keep the directory & reinstall CKEditor by overriding files',
-                            CKEditorInstaller::CLEAR_ABORT => 'Abort installation',
+                            CKEditorInstaller::CLEAR_DROP => 'Drop the directory & reinstall CKEditor',
+                            CKEditorInstaller::CLEAR_KEEP => 'Keep the directory & reinstall CKEditor by overriding files',
+                            CKEditorInstaller::CLEAR_SKIP => 'Skip installation',
                         ],
                         CKEditorInstaller::CLEAR_DROP,
                         $input,
@@ -265,6 +267,15 @@ EOF
     private function success($message, OutputInterface $output)
     {
         $this->block('[OK] - '.$message, $output, 'green', 'black');
+    }
+
+    /**
+     * @param string          $message
+     * @param OutputInterface $output
+     */
+    private function info($message, OutputInterface $output)
+    {
+        $this->block('[INFO] - '.$message, $output, 'orange', 'black');
     }
 
     /**

--- a/Composer/CKEditorScriptHandler.php
+++ b/Composer/CKEditorScriptHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Composer;
+
+use Composer\Script\CommandEvent;
+use Composer\Script\Event;
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class CKEditorScriptHandler extends ScriptHandler
+{
+    /**
+     * @param CommandEvent|Event $event
+     */
+    public static function install($event)
+    {
+        static::executeCommand(
+            $event,
+            static::getConsoleDir($event, 'Install CKEditor'),
+            static::createCommand($event)
+        );
+    }
+
+    /**
+     * @param CommandEvent|Event $event
+     *
+     * @return string
+     */
+    protected static function createCommand($event)
+    {
+        $extra = $event->getComposer()->getPackage()->getExtra();
+        $command = 'ckeditor:install';
+
+        if (isset($extra['ckeditor-path'])) {
+            $command .= ' '.$extra['ckeditor-path'];
+        }
+
+        if (isset($extra['ckeditor-release'])) {
+            $command .= ' --release='.$extra['ckeditor-release'];
+        }
+
+        if (isset($extra['ckeditor-tag'])) {
+            $command .= ' --tag='.$extra['ckeditor-tag'];
+        }
+
+        if (isset($extra['ckeditor-clear'])) {
+            $command .= ' --clear='.$extra['ckeditor-clear'];
+        }
+
+        if (isset($extra['ckeditor-exclude'])) {
+            foreach ($extra['ckeditor-exclude'] as $exclude) {
+                $command .= ' --exclude='.$exclude;
+            }
+        }
+
+        return $command;
+    }
+}

--- a/Installer/CKEditorInstaller.php
+++ b/Installer/CKEditorInstaller.php
@@ -24,7 +24,7 @@ class CKEditorInstaller
 
     const CLEAR_DROP = 'drop';
     const CLEAR_KEEP = 'keep';
-    const CLEAR_ABORT = 'abort';
+    const CLEAR_SKIP = 'skip';
 
     const NOTIFY_CLEAR = 'clear';
     const NOTIFY_CLEAR_ARCHIVE = 'clear-archive';
@@ -90,7 +90,7 @@ class CKEditorInstaller
         $this->path = $path ?: dirname(__DIR__).'/Resources/public';
         $this->release = $release ?: self::RELEASE_FULL;
         $this->version = $version ?: self::VERSION_LATEST;
-        $this->clear = $clear ?: self::CLEAR_DROP;
+        $this->clear = $clear ?: self::CLEAR_SKIP;
         $this->excludes = $excludes;
     }
 
@@ -105,7 +105,7 @@ class CKEditorInstaller
         $clear = isset($options['clear']) ? $options['clear'] : null;
         $notifier = isset($options['notifier']) ? $options['notifier'] : null;
 
-        if ($this->clear($path, $clear, $notifier) === self::CLEAR_ABORT) {
+        if ($this->clear($path, $clear, $notifier) === self::CLEAR_SKIP) {
             return false;
         }
 

--- a/Resources/doc/usage/ckeditor.rst
+++ b/Resources/doc/usage/ckeditor.rst
@@ -21,7 +21,7 @@ assets installation).
                 "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
                 "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
                 "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-                "php bin/console ckeditor:install --clear=drop",
+                "Ivory\\CKEditorBundle\\Composer\\CKEditorScriptHandler::install",
                 "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
                 "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
                 "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
@@ -52,6 +52,14 @@ Download Path
 If you don't want to download CKEditor in the ``Resource/public`` directory of
 the bundle, you can use a custom path (absolute):
 
+.. code-block:: json
+
+    {
+        "extra": {
+            "ckeditor-path": "/var/www/html/web/ckeditor"
+        }
+    }
+
 .. code-block:: bash
 
     $ php bin/console ckeditor:install /var/www/html/web/ckeditor
@@ -61,6 +69,14 @@ CKEditor Release
 
 You can choose which CKEditor release (full, standard or basic) to download:
 
+.. code-block:: json
+
+    {
+        "extra": {
+            "ckeditor-release": "basic"
+        }
+    }
+
 .. code-block:: bash
 
     $ php bin/console ckeditor:install --release=basic
@@ -69,6 +85,14 @@ CKEditor Version
 ~~~~~~~~~~~~~~~~
 
 If your want a specific CKEditor version, you can use:
+
+.. code-block:: json
+
+    {
+        "extra": {
+            "ckeditor-tag": "4.6.0"
+        }
+    }
 
 .. code-block:: bash
 
@@ -81,22 +105,40 @@ By default, the command will ask you what to do when there is a previous CKEdito
 installation detected but in non interactive mode, you can control automatically
 how to handle such case:
 
+.. code-block:: json
+
+    {
+        "extra": {
+            "ckeditor-clear": "drop"
+        }
+    }
+
 .. code-block:: bash
 
     $ php bin/console ckeditor:install --clear=drop
     $ php bin/console ckeditor:install --clear=keep
-    $ php bin/console ckeditor:install --clear=abort
-
+    $ php bin/console ckeditor:install --clear=skip
 
  - ``drop``: Drop the previous installation & install.
  - ``keep``: Keep the previous installation & install by overriding files.
- - ``abort``: Keep the previous installation & abort install.
+ - ``skip``: Keep the previous installation & skip install.
 
 Path Exclusion
 ~~~~~~~~~~~~~~
 
 When extracting the downloaded CKEditor ZIP archive, you can exclude paths
 such as samples, adapters, whatever:
+
+.. code-block:: json
+
+    {
+        "extra": {
+            "ckeditor-exclude": [
+                "samples",
+                "adapters"
+            ]
+        }
+    }
 
 .. code-block:: bash
 

--- a/Tests/Composer/CKEditorScriptHandlerTest.php
+++ b/Tests/Composer/CKEditorScriptHandlerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\CKEditorBundle\Tests\Composer;
+
+use Composer\Composer;
+use Composer\Config;
+use Composer\IO\IOInterface;
+use Composer\Package\Package;
+use Composer\Script\CommandEvent;
+use Composer\Script\Event;
+use Ivory\CKEditorBundle\Composer\CKEditorScriptHandler;
+use Ivory\CKEditorBundle\Installer\CKEditorInstaller;
+use Ivory\CKEditorBundle\Tests\AbstractTestCase;
+
+/**
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class CKEditorScriptHandlerTest extends AbstractTestCase
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->path = __DIR__.'/../../Resources/public';
+
+        $this->tearDown();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        if (file_exists($this->path)) {
+            exec('rm -rf '.$this->path);
+        }
+    }
+
+    public function testInstall()
+    {
+        CKEditorScriptHandler::install($this->createEventMock());
+        $this->assertInstall();
+    }
+
+    public function testReinstall()
+    {
+        CKEditorScriptHandler::install($this->createEventMock());
+        $this->assertInstall();
+
+        CKEditorScriptHandler::install($this->createEventMock());
+        $this->assertInstall();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Event
+     */
+    private function createEventMock()
+    {
+        $config = $this->createMock(Config::class);
+        $config
+            ->expects($this->any())
+            ->method('get')
+            ->will($this->returnValueMap([
+                ['process-timeout', 300],
+                ['vendor-dir', __DIR__.'/../../vendor'],
+            ]));
+
+        $package = $this->getMockBuilder(Package::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $package
+            ->expects($this->any())
+            ->method('getExtra')
+            ->will($this->returnValue([
+                'ckeditor-clear'  => CKEditorInstaller::CLEAR_DROP,
+                'symfony-bin-dir' => __DIR__.'/../Fixtures',
+                'symfony-var-dir' => __DIR__.'/../Fixtures',
+            ]));
+
+        $composer = $this->createMock(Composer::class);
+        $composer
+            ->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue($config));
+
+        $composer
+            ->expects($this->any())
+            ->method('getPackage')
+            ->will($this->returnValue($package));
+
+        $io = $this->createMock(IOInterface::class);
+
+        $event = $this->getMockBuilder(class_exists(CommandEvent::class) ? CommandEvent::class : Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event
+            ->expects($this->any())
+            ->method('getComposer')
+            ->will($this->returnValue($composer));
+
+        $event
+            ->expects($this->any())
+            ->method('getIO')
+            ->will($this->returnValue($io));
+
+        return $event;
+    }
+
+    private function assertInstall()
+    {
+        $this->assertFileExists($this->path.'/ckeditor.js');
+    }
+}

--- a/Tests/Fixtures/console
+++ b/Tests/Fixtures/console
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Ivory CKEditor package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Ivory\CKEditorBundle\Command\CKEditorInstallerCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+$application = new Application();
+$application->add(new CKEditorInstallerCommand());
+$application->run(new ArgvInput());

--- a/Tests/Installer/CKEditorInstallerTest.php
+++ b/Tests/Installer/CKEditorInstallerTest.php
@@ -117,10 +117,10 @@ class CKEditorInstallerTest extends AbstractTestCase
         $this->assertInstall($options);
     }
 
-    public function testReinstallWithClearAbort()
+    public function testReinstallWithClearSkip()
     {
         $this->installer->install($options = ['version' => '4.6.0']);
-        $this->installer->install(['clear' => CKEditorInstaller::CLEAR_ABORT]);
+        $this->installer->install(['clear' => CKEditorInstaller::CLEAR_SKIP]);
 
         $this->assertInstall($options);
     }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,10 @@
         "symfony/framework-bundle": "^2.7|^3.0"
     },
     "require-dev": {
+        "composer/composer": "^1.0",
         "friendsofphp/php-cs-fixer": "^2.0",
         "phpunit/phpunit": "^5.0|^6.0",
+        "sensio/distribution-bundle": "^3.0.12|^4.0|^5.0",
         "symfony/asset": "^2.7|^3.0",
         "symfony/console": "^2.7|^3.0",
         "symfony/phpunit-bridge": "^2.7|^3.0",
@@ -30,6 +32,7 @@
     },
     "suggest": {
         "egeloen/form-extra-bundle": "Allows to load CKEditor asynchronously",
+        "sensio/distribution-bundle": "Allows to install CKEditor via a script handler",
         "symfony/asset": "Allows to rewrite/version assets",
         "symfony/templating": "Allows to use PHP templates",
         "symfony/twig-bridge": "Allows to use Twig templates",


### PR DESCRIPTION
This PR introduces a Composer script handler which installs CKEditor source as suggested in https://github.com/symfony/recipes-contrib/issues/57

It also renames the clear abort option to skip and make it the default value in order to not accidentally upgrade CKEditor source.