### PR TITLE
bin/console ckeditor:install --quiet doesnt work after updating Symfony to v3.4.3

### DIFF
--- a/Command/CKEditorInstallerCommand.php
+++ b/Command/CKEditorInstallerCommand.php
@@ -323,7 +323,7 @@ EOF
         $result = $helper->ask($input, $output, new ChoiceQuestion(
             $question,
             $choices,
-            $choices[$default]
+            $default
         ));
 
         $output->writeln('');

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "egeloen/json-builder": "^2.0|^3.0",
         "symfony/dependency-injection": "^2.7|^3.0",
         "symfony/form": "^2.7|^3.0",
-        "symfony/framework-bundle": "^2.7|^3.0"
+        "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/console": "~2.7.40|~2.8.33|~3.3.15|~3.4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/dependency-injection": "^2.7|^3.0",
         "symfony/form": "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0"
+        "symfony/console": "~2.7.40|~2.8.33|~3.3.15|~3.4.3"
     },
     "require-dev": {
         "composer/composer": "^1.0",
@@ -23,7 +24,7 @@
         "phpunit/phpunit": "^5.0|^6.0",
         "sensio/distribution-bundle": "^3.0.12|^4.0|^5.0",
         "symfony/asset": "^2.7|^3.0",
-        "symfony/console": "^2.7|^3.0",
+        "symfony/console": "~2.7.40|~2.8.33|~3.3.15|~3.4.3",
         "symfony/phpunit-bridge": "^2.7|^3.0",
         "symfony/templating": "^2.7|^3.0",
         "symfony/twig-bridge": "^2.7|^3.0",


### PR DESCRIPTION
After I have updated symfony from 3.4.2 to 3.4.3 the console command `bin/console ckeditor:install --quiet` stopped working, exitting with error code 1:

> In QuestionHelper.php line 53:
> 
>   Notice: Undefined index: Drop the directory & reinstall CKEditor
> 
> 
> ckeditor:install [--release [RELEASE]] [--tag [TAG]] [--clear [CLEAR]] [--exclude [EXCLUDE]] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> [<path>]
> 
> Script bin/console ckeditor:install --quiet handling the symfony-scripts event returned with error code 1